### PR TITLE
fix: remove root-level description from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "pydantic-skills",
-  "description": "Official Pydantic plugin marketplace for Claude Code - Logfire instrumentation",
   "owner": {
     "name": "Pydantic",
     "email": "support@pydantic.dev"


### PR DESCRIPTION
Remove the root-level description key from .claude-plugin/marketplace.json. The description is already present in each plugins[] entry where it belongs. Root-level description can cause validation failures during plugin distribution.