### PR TITLE
Inlining references from the routing table

### DIFF
--- a/plugins/ai/skills/building-pydantic-ai-agents/SKILL.md
+++ b/plugins/ai/skills/building-pydantic-ai-agents/SKILL.md
@@ -7,7 +7,7 @@ description: >
 license: MIT
 compatibility: Requires Python 3.10+
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   author: pydantic
 ---
 
@@ -212,58 +212,25 @@ agent = Agent.from_file('agent.yaml')
 
 ## Task Routing Table
 
-| I want to... | Documentation |
+Load only the most relevant reference first. Read additional references only if the task spans multiple areas.
+
+| I want to... | Reference |
 |---|---|
-| Create or configure agents | [Agents](https://ai.pydantic.dev/agents/) |
-| Bundle reusable behavior (tools, hooks, instructions) | [Capabilities](https://ai.pydantic.dev/capabilities/) |
-| Intercept model requests, tool calls, or runs | [Hooks](https://ai.pydantic.dev/hooks/) |
-| Define agents in YAML/JSON without Python code | [Agent Specs](https://ai.pydantic.dev/agent-spec/) |
-| Use template strings in agent instructions | [Template Strings](https://ai.pydantic.dev/agent-spec/#template-strings) |
-| Let my agent call external APIs or functions | [Tools](https://ai.pydantic.dev/tools/) |
-| Organize or restrict which tools an agent can use | [Toolsets](https://ai.pydantic.dev/toolsets/) |
-| Give my agent web search with automatic provider fallback | [WebSearch Capability](https://ai.pydantic.dev/capabilities/#provider-adaptive-tools) |
-| Give my agent URL fetching with automatic provider fallback | [WebFetch Capability](https://ai.pydantic.dev/capabilities/#provider-adaptive-tools) |
-| Give my agent web search or code execution (builtin tools) | [Built-in Tools](https://ai.pydantic.dev/builtin-tools/) |
-| Search with DuckDuckGo/Tavily/Exa | [Common Tools](https://ai.pydantic.dev/common-tools/) |
-| Ensure my agent returns data in a specific format | [Structured Output](https://ai.pydantic.dev/output/#structured-output) |
-| Pass database connections, API clients, or config to tools | [Dependencies](https://ai.pydantic.dev/dependencies/) |
-| Access usage stats, message history, or retry count in tools | [RunContext](https://ai.pydantic.dev/tools/) |
-| Choose or configure models | [Models](https://ai.pydantic.dev/models/) |
-| Automatically switch to backup model when primary fails | [Fallback Model](https://ai.pydantic.dev/models/#fallback-model) |
-| Show real-time progress as my agent works | [Streaming Events and Final Output](https://ai.pydantic.dev/agents/#streaming-events-and-final-output) |
-| Work with messages and multimedia | [Message History](https://ai.pydantic.dev/message-history/) |
-| Reduce token costs by trimming or filtering conversation history | [Processing Message History](https://ai.pydantic.dev/message-history/#processing-message-history) |
-| Keep long conversations manageable without losing context | [Summarize Old Messages](https://ai.pydantic.dev/message-history/#summarize-old-messages) |
-| Use MCP servers | [MCP](https://ai.pydantic.dev/mcp/) |
-| Build multi-step graphs | [Graph](https://ai.pydantic.dev/graph/) |
-| Debug a failed agent run or see what went wrong | [Model Errors](https://ai.pydantic.dev/agents/#model-errors) |
-| Make my agent resilient to temporary failures | [Retries](https://ai.pydantic.dev/retries/) |
-| Understand why my agent made specific decisions | [Using Logfire](https://ai.pydantic.dev/logfire/#using-logfire) |
-| Write deterministic tests for my agent | [Unit testing with TestModel](https://ai.pydantic.dev/testing/#unit-testing-with-testmodel) |
-| Enable thinking/reasoning across any provider | [Thinking](https://ai.pydantic.dev/thinking/) · [Thinking Capability](https://ai.pydantic.dev/capabilities/#thinking) |
-| Systematically verify my agent works correctly | [Evals](https://ai.pydantic.dev/evals/) |
-| Use embeddings for RAG | [Embeddings](https://ai.pydantic.dev/embeddings/) |
-| Use durable execution | [Durable Execution](https://ai.pydantic.dev/durable_execution/overview/) |
-| Have one agent delegate tasks to another | [Agent Delegation](https://ai.pydantic.dev/multi-agent-applications/#agent-delegation) |
-| Route requests to different agents based on intent | [Programmatic Agent Hand-off](https://ai.pydantic.dev/multi-agent-applications/#programmatic-agent-hand-off) |
-| Require tool approval (human-in-the-loop) | [Deferred Tools](https://ai.pydantic.dev/deferred-tools/) |
-| Use images, audio, video, or documents | [Input](https://ai.pydantic.dev/input/) |
-| Use advanced tool features | [Advanced Tools](https://ai.pydantic.dev/tools-advanced/) |
-| Validate or require approval before tool execution | [Advanced Tools](https://ai.pydantic.dev/tools-advanced/) |
-| Call the model without using an agent | [Direct API](https://ai.pydantic.dev/direct/) |
-| Expose agents as HTTP servers (A2A) | [A2A](https://ai.pydantic.dev/a2a/) |
-| Handle network errors and rate limiting automatically | [Retries](https://ai.pydantic.dev/retries/) |
-| Use LangChain or ACI.dev tools | [Third-Party Tools](https://ai.pydantic.dev/third-party-tools/) |
-| Publish reusable agent extensions as packages | [Extensibility](https://ai.pydantic.dev/extensibility/) |
-| Build custom toolsets, models, or agents | [Extensibility](https://ai.pydantic.dev/extensibility/) |
-| Debug common issues | [Troubleshooting](https://ai.pydantic.dev/troubleshooting/) |
-| Migrate from deprecated APIs | [Changelog](https://ai.pydantic.dev/changelog/) |
-| See advanced real-world examples | [Examples](https://ai.pydantic.dev/examples/) |
-| Look up an import path | [API Reference](https://ai.pydantic.dev/api/) |
+| Create/configure agents, choose output types, use deps, define specs, or pick run methods | [Agents Core](./references/AGENTS-CORE.md) |
+| Bundle reusable behavior or intercept lifecycle events | [Capabilities and Hooks](./references/CAPABILITIES-AND-HOOKS.md) |
+| Add function tools, toolsets, MCP servers, or explicit search tools | [Tools Core](./references/TOOLS-CORE.md) |
+| Use provider-native web search, web fetch, or code execution | [Built-in Tools](./references/BUILTIN-TOOLS.md) |
+| Use advanced tool features such as approval, retries, `ToolReturn`, validators, timeouts, or tool search | [Tools Advanced](./references/TOOLS-ADVANCED.md) |
+| Work with multimodal input, message history, or context trimming | [Input and History](./references/INPUT-AND-HISTORY.md) |
+| Test or debug agent behavior | [Testing and Debugging](./references/TESTING-AND-DEBUGGING.md) |
+| Coordinate multiple agents or build graph workflows | [Orchestration and Integrations](./references/ORCHESTRATION-AND-INTEGRATIONS.md#coordinate-multiple-agents) |
+| Call the model directly, expose A2A, use durable execution, embeddings, evals, or third-party integrations | [Orchestration and Integrations](./references/ORCHESTRATION-AND-INTEGRATIONS.md) |
+| Compare abstractions, output modes, decorators, or model-string patterns | [Architecture and Decision Guide](./references/ARCHITECTURE.md) |
+| Follow an older link into `COMMON-TASKS.md` | [Task Reference Map](./references/COMMON-TASKS.md) |
 
 ## Architecture and Decisions
 
-Load [Architecture and Decision Guide](./references/ARCHITECTURE.md) for detailed decision trees, comparison tables, and architecture overview:
+Load [Architecture and Decision Guide](./references/ARCHITECTURE.md) only when the user is choosing between abstractions or wants comparison tables and decision trees:
 
 | Topic | What it covers |
 |---|---|
@@ -278,7 +245,7 @@ Load [Architecture and Decision Guide](./references/ARCHITECTURE.md) for detaile
 ## Key Practices
 
 - **Python 3.10+** compatibility required
-- **Observability**: Pydantic AI has first-class integration with [Logfire](https://logfire.pydantic.dev/) for tracing agent runs, tool calls, and model requests. Add it with `logfire.instrument_pydantic_ai()`. For deeper HTTP-level visibility, `logfire.instrument_httpx(capture_all=True)` captures the exact payloads sent to model providers.
+- **Observability**: Pydantic AI has first-class integration with Logfire for tracing agent runs, tool calls, and model requests. Add it with `logfire.instrument_pydantic_ai()`. For deeper HTTP-level visibility, `logfire.instrument_httpx(capture_all=True)` captures the exact payloads sent to model providers.
 - **Testing**: Use `TestModel` for deterministic tests, `FunctionModel` for custom logic
 
 ## Common Gotchas
@@ -292,19 +259,19 @@ These are mistakes agents commonly make with Pydantic AI. Getting these wrong pr
 - **Hook decorator names on `.on` don't repeat `on_`**: Use `hooks.on.run_error` and `hooks.on.model_request_error` — not `hooks.on.on_run_error`.
 - **`history_processors` is plural**: The Agent parameter is `history_processors=[...]`, not `history_processor=`.
 
-## Common Tasks
+## Task-Family References
 
-Load [Common Tasks Reference](./references/COMMON-TASKS.md) for detailed implementation guidance with code examples:
+Load exactly one of these unless the task clearly spans multiple families:
 
-| Task | Section |
+| Task family | Reference |
 |---|---|
-| Add capabilities (Thinking, WebSearch, etc.) | Add Capabilities to an Agent |
-| Intercept model requests and tool calls | Intercept Agent Lifecycle with Hooks |
-| Define agents from YAML/JSON config files | Define Agents Declaratively with Specs |
-| Enable thinking/reasoning across providers | Enable Thinking Across Providers |
-| Trim or filter conversation history | Manage Context Size |
-| Stream events and show real-time progress | Show Real-Time Progress |
-| Auto-switch providers on failure | Handle Provider Failures |
-| Write deterministic tests | Test Agent Behavior |
-| Delegate tasks between agents | Coordinate Multiple Agents |
-| Instrument with Logfire for debugging | Debug and Validate Agent Behavior |
+| Core agent setup, output, deps, specs, models, run methods | [Agents Core](./references/AGENTS-CORE.md) |
+| Capabilities, hooks, and reusable behavior | [Capabilities and Hooks](./references/CAPABILITIES-AND-HOOKS.md) |
+| Function tools, toolsets, MCP, explicit search tools | [Tools Core](./references/TOOLS-CORE.md) |
+| Provider-native builtin tools | [Built-in Tools](./references/BUILTIN-TOOLS.md) |
+| Approval, retries, validators, timeouts, rich tool returns, deferred loading | [Tools Advanced](./references/TOOLS-ADVANCED.md) |
+| Multimodal input, message history, history processors | [Input and History](./references/INPUT-AND-HISTORY.md) |
+| Testing, request inspection, and Logfire debugging | [Testing and Debugging](./references/TESTING-AND-DEBUGGING.md) |
+| Multi-agent patterns, graphs, direct API, A2A, durable execution, embeddings, evals, third-party integrations | [Orchestration and Integrations](./references/ORCHESTRATION-AND-INTEGRATIONS.md) |
+
+Use [Task Reference Map](./references/COMMON-TASKS.md) only for compatibility with older links or when you need a pointer from an old section name to the new file.

--- a/plugins/ai/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
+++ b/plugins/ai/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
@@ -1,0 +1,158 @@
+# Agents Core
+
+Read this file when the user needs the core `Agent` workflow: creating agents, choosing output types, using dependencies, defining specs, selecting models, or choosing how to run/stream an agent.
+
+## Create a Basic Agent
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    instructions='Be concise, reply with one sentence.',
+)
+
+result = agent.run_sync('Where does "hello world" come from?')
+print(result.output)
+```
+
+## Structured Output with Pydantic Models
+
+Use `output_type=MyModel` when the model should return validated structured data.
+
+```python
+from pydantic import BaseModel
+
+from pydantic_ai import Agent
+
+
+class CityLocation(BaseModel):
+    city: str
+    country: str
+
+
+agent = Agent('google-gla:gemini-3-flash-preview', output_type=CityLocation)
+result = agent.run_sync('Where were the olympics held in 2012?')
+print(result.output)
+```
+
+If the user is choosing between output modes:
+
+- `output_type=str` for plain text
+- `output_type=MyModel` for structured output
+- `TextOutput` for custom text parsing
+- `NativeOutput` or `ToolOutput` when they need explicit output-mode control
+
+## Dependency Injection
+
+Use `deps_type=...` plus `RunContext[...]` when tools or instructions need app state.
+
+```python
+from pydantic_ai import Agent, RunContext
+
+agent = Agent('openai:gpt-5.2', deps_type=str)
+
+
+@agent.instructions
+def add_user_name(ctx: RunContext[str]) -> str:
+    return f"The user's name is {ctx.deps}."
+```
+
+Use `@agent.tool` when the tool needs `RunContext`. Use `@agent.tool_plain` when it does not.
+
+## Define Agents Declaratively with Specs
+
+Use YAML or JSON specs when configuration should live outside Python code.
+
+```yaml
+model: anthropic:claude-opus-4-6
+instructions: "You are helping {{user_name}} with research."
+capabilities:
+  - WebSearch
+  - Thinking:
+      effort: high
+```
+
+```python
+from dataclasses import dataclass
+
+from pydantic_ai import Agent
+
+
+@dataclass
+class UserContext:
+    user_name: str
+
+
+agent = Agent.from_file('agent.yaml', deps_type=UserContext)
+result = agent.run_sync('Find recent papers on AI safety', deps=UserContext(user_name='Alice'))
+```
+
+Template strings are part of the spec flow, so route template-string questions here too.
+
+## Choose or Configure Models
+
+Model strings use the `"provider:model-name"` format.
+
+Examples:
+
+- `openai:gpt-5.2`
+- `anthropic:claude-sonnet-4-6`
+- `google-gla:gemini-3-pro-preview`
+
+Use a model instance instead of a string when the user needs provider-specific constructor arguments.
+
+## Run Methods and Streaming
+
+Pick a run method based on the interaction pattern:
+
+- `run()` for async runs that complete normally
+- `run_sync()` for synchronous scripts and notebooks
+- `run_stream()` for streaming final output
+- `run_stream_sync()` for sync streaming
+- `run_stream_events()` when the caller needs the typed event stream directly
+- `iter()` when the caller needs step-by-step control over the agent loop
+
+Use `event_stream_handler=` with `run()` or `run_stream()` when the user wants progress updates without manually consuming the event stream:
+
+```python
+from collections.abc import AsyncIterable
+
+from pydantic_ai import Agent, AgentStreamEvent, FunctionToolCallEvent, RunContext
+
+agent = Agent('openai:gpt-5.2')
+
+
+async def stream_handler(ctx: RunContext[None], events: AsyncIterable[AgentStreamEvent]):
+    async for event in events:
+        if isinstance(event, FunctionToolCallEvent):
+            print(f'Calling {event.part.tool_name}...')
+
+
+async def main():
+    await agent.run('Do the task', event_stream_handler=stream_handler)
+```
+
+## Handle Provider Failures
+
+Use `FallbackModel` when the user wants automatic provider or model failover.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.models.fallback import FallbackModel
+from pydantic_ai.models.openai import OpenAIChatModel
+
+fallback = FallbackModel(
+    OpenAIChatModel('gpt-5.2'),
+    AnthropicModel('claude-sonnet-4-6'),
+)
+
+agent = Agent(fallback)
+```
+
+Good defaults:
+
+- primary expensive/strong model, cheaper fallback for resilience
+- same prompt/output contract across both models
+- per-model settings only when the user actually needs them

--- a/plugins/ai/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
+++ b/plugins/ai/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
@@ -2,6 +2,39 @@
 
 Detailed decision trees, comparison tables, and architecture overview for Pydantic AI.
 
+## Contents
+
+- [Task-Family References](#task-family-references)
+- [Decision Trees](#decision-trees)
+  - [Choosing a Tool Registration Method](#choosing-a-tool-registration-method)
+  - [Choosing an Output Mode](#choosing-an-output-mode)
+  - [Choosing a Multi-Agent Pattern](#choosing-a-multi-agent-pattern)
+  - [Choosing How to Extend Agent Behavior](#choosing-how-to-extend-agent-behavior)
+  - [Choosing a Capability](#choosing-a-capability)
+  - [Choosing a Testing Approach](#choosing-a-testing-approach)
+- [Comparison Tables](#comparison-tables)
+  - [Output Mode Comparison](#output-mode-comparison)
+  - [Model Provider Prefixes](#model-provider-prefixes)
+  - [Tool Decorator Comparison](#tool-decorator-comparison)
+  - [Built-in Capabilities](#built-in-capabilities)
+  - [When to Use Each Agent Method](#when-to-use-each-agent-method)
+- [Architecture Overview](#architecture-overview)
+
+## Task-Family References
+
+Use this file for comparisons and abstraction choices.
+
+If the user already knows what they want to do, load the narrower task guide instead:
+
+- [AGENTS-CORE.md](./AGENTS-CORE.md)
+- [CAPABILITIES-AND-HOOKS.md](./CAPABILITIES-AND-HOOKS.md)
+- [TOOLS-CORE.md](./TOOLS-CORE.md)
+- [BUILTIN-TOOLS.md](./BUILTIN-TOOLS.md)
+- [TOOLS-ADVANCED.md](./TOOLS-ADVANCED.md)
+- [INPUT-AND-HISTORY.md](./INPUT-AND-HISTORY.md)
+- [TESTING-AND-DEBUGGING.md](./TESTING-AND-DEBUGGING.md)
+- [ORCHESTRATION-AND-INTEGRATIONS.md](./ORCHESTRATION-AND-INTEGRATIONS.md)
+
 ## Decision Trees
 
 ### Choosing a Tool Registration Method
@@ -127,7 +160,7 @@ Need deterministic, fast tests?
 | Cerebras | `cerebras:` | `cerebras:llama-4-scout-17b-16e-instruct` |
 | Heroku | `heroku:` | `heroku:claude-sonnet-4-6` |
 
-**Additional prefixes:** `litellm:`, `nebius:`, `ovhcloud:`, `alibaba:`, `sambanova:`, `vercel:`, `outlines:`, `moonshotai:`. For truly custom providers, subclass `Model` or use `OpenAIChatModel` with a custom `base_url`. See [Models](https://ai.pydantic.dev/models/).
+**Additional prefixes:** `litellm:`, `nebius:`, `ovhcloud:`, `alibaba:`, `sambanova:`, `vercel:`, `outlines:`, `moonshotai:`. For truly custom providers, subclass `Model` or use `OpenAIChatModel` with a custom `base_url`.
 
 ### Tool Decorator Comparison
 
@@ -165,7 +198,7 @@ Need deterministic, fast tests?
 | Receiving an async iterable of typed events (tool calls, results, final output) | `agent.run_stream_events()` |
 | Inspecting or modifying state between agent steps, human-in-the-loop approval | `agent.iter()` |
 
-See [Streaming All Events](https://ai.pydantic.dev/agents/#streaming-all-events) for `event_stream_handler` details.
+See [Run Methods and Streaming](./AGENTS-CORE.md#run-methods-and-streaming) for `event_stream_handler` details.
 
 ## Architecture Overview
 

--- a/plugins/ai/skills/building-pydantic-ai-agents/references/BUILTIN-TOOLS.md
+++ b/plugins/ai/skills/building-pydantic-ai-agents/references/BUILTIN-TOOLS.md
@@ -1,0 +1,66 @@
+# Built-in Tools
+
+Read this file when the user wants provider-native tools such as web search, web fetch, code execution, memory, or file search.
+
+Prefer capabilities like `WebSearch()` or `WebFetch()` when the user wants a provider-agnostic solution. Use built-in tools directly when they explicitly want provider-native behavior or provider-specific configuration.
+
+## Give My Agent Web Search or Code Execution
+
+Builtin tools are passed via `builtin_tools=[...]`.
+
+```python
+from pydantic_ai import Agent, WebSearchTool
+
+agent = Agent('openai-responses:gpt-5.2', builtin_tools=[WebSearchTool()])
+result = agent.run_sync('Give me a sentence with the biggest news in AI this week.')
+print(result.output)
+```
+
+For OpenAI web search, use the Responses API model prefix (`openai-responses:`), not `openai:`.
+
+## Built-in Tool Defaults
+
+Reach for these when the provider supports them:
+
+- `WebSearchTool`
+- `WebFetchTool`
+- `CodeExecutionTool`
+- `ImageGenerationTool`
+- `MemoryTool`
+- `MCPServerTool`
+- `FileSearchTool`
+
+## Dynamic Built-in Tool Configuration
+
+Prepare built-in tools from `RunContext` when configuration depends on the current user or request.
+
+```python
+from pydantic_ai import Agent, RunContext, WebSearchTool
+
+
+async def prepared_web_search(ctx: RunContext[dict]) -> WebSearchTool | None:
+    if not ctx.deps.get('location'):
+        return None
+    return WebSearchTool(user_location={'city': ctx.deps['location']})
+
+
+agent = Agent(
+    'openai-responses:gpt-5.2',
+    builtin_tools=[prepared_web_search],
+    deps_type=dict,
+)
+```
+
+## When to Use Built-in Tools vs Capabilities
+
+Use built-in tools when:
+
+- the user explicitly wants provider-native behavior
+- the provider-specific configuration matters
+- the user already picked a provider that supports the tool
+
+Use capabilities when:
+
+- the code should work across providers
+- you want local fallback when builtin support is missing
+- the user has not committed to a provider yet

--- a/plugins/ai/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
+++ b/plugins/ai/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
@@ -1,0 +1,102 @@
+# Capabilities and Hooks
+
+Read this file when the user wants reusable agent behavior, provider-adaptive tools, or lifecycle interception.
+
+## Add Capabilities to an Agent
+
+Capabilities bundle reusable behavior and compose automatically.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import Thinking, WebSearch
+
+agent = Agent(
+    'anthropic:claude-opus-4-6',
+    capabilities=[
+        Thinking(effort='high'),
+        WebSearch(),
+    ],
+)
+```
+
+Provider-adaptive capabilities to reach for first:
+
+- `Thinking`
+- `WebSearch`
+- `WebFetch`
+- `ImageGeneration`
+- `MCP`
+
+Use capabilities when the user wants behavior that should survive model/provider changes.
+
+## Enable Thinking Across Providers
+
+Use the unified `Thinking` capability or the `thinking` model setting.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import Thinking
+
+agent = Agent('anthropic:claude-opus-4-6', capabilities=[Thinking(effort='high')])
+agent = Agent('anthropic:claude-opus-4-6', model_settings={'thinking': 'high'})
+```
+
+Supported effort values:
+
+- `True`
+- `False`
+- `'minimal'`
+- `'low'`
+- `'medium'`
+- `'high'`
+- `'xhigh'`
+
+## Intercept Agent Lifecycle with Hooks
+
+Use `Hooks` for decorator-based lifecycle interception.
+
+```python
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.capabilities.hooks import Hooks
+from pydantic_ai.models import ModelRequestContext
+
+hooks = Hooks()
+
+
+@hooks.on.before_model_request
+async def log_request(ctx: RunContext[None], request_context: ModelRequestContext) -> ModelRequestContext:
+    print(f'Sending {len(request_context.messages)} messages')
+    return request_context
+
+
+@hooks.on.before_tool_execute(tools=['send_email'])
+async def audit_tool(ctx, *, call, tool_def, args):
+    print(f'Executing {call.tool_name}')
+    return args
+
+
+agent = Agent('openai:gpt-5.2', capabilities=[hooks])
+```
+
+Important hook families:
+
+- run-level hooks
+- node-level hooks
+- model-request hooks
+- tool-validation hooks
+- tool-execution hooks
+- event-stream hooks
+
+Use hooks when the user wants observability, auditing, or light interception without adding a new abstraction.
+
+## Build a Custom Capability
+
+Subclass `AbstractCapability` when the user wants reusable behavior that combines tools, hooks, instructions, or model settings into one package.
+
+Reach for a custom capability when:
+
+- the same bundle should be reused across multiple agents
+- `Hooks` alone is not enough
+- the behavior should be installable or declarative
+
+Keep custom capabilities focused. If the user only needs one tool or one hook, do not introduce a capability.

--- a/plugins/ai/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
+++ b/plugins/ai/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
@@ -1,274 +1,108 @@
-# Common Tasks
+# Task Reference Map
 
-Detailed implementation guidance with code examples for common Pydantic AI tasks.
+This file exists as a compatibility index for older links into `COMMON-TASKS.md`.
+
+Prefer the narrower task-family guides below so the agent loads only the material it needs:
+
+- [AGENTS-CORE.md](./AGENTS-CORE.md) — agent creation, output, deps, specs, models, run methods
+- [CAPABILITIES-AND-HOOKS.md](./CAPABILITIES-AND-HOOKS.md) — `Thinking`, `WebSearch`, `Hooks`, custom capabilities
+- [TOOLS-CORE.md](./TOOLS-CORE.md) — `@agent.tool`, `Tool`, toolsets, MCP, common search tools
+- [BUILTIN-TOOLS.md](./BUILTIN-TOOLS.md) — provider-native tools like `WebSearchTool` and `CodeExecutionTool`
+- [TOOLS-ADVANCED.md](./TOOLS-ADVANCED.md) — approval, retries, `ToolReturn`, timeouts, validators, deferred loading
+- [INPUT-AND-HISTORY.md](./INPUT-AND-HISTORY.md) — multimodal input, message history, history processors
+- [TESTING-AND-DEBUGGING.md](./TESTING-AND-DEBUGGING.md) — `TestModel`, `FunctionModel`, `capture_run_messages`, Logfire
+- [ORCHESTRATION-AND-INTEGRATIONS.md](./ORCHESTRATION-AND-INTEGRATIONS.md) — multi-agent patterns, graphs, A2A, direct API, durable execution, embeddings, evals, third-party tools
 
 ## Add Capabilities to an Agent
 
-Use capabilities to bundle reusable behavior. Multiple capabilities compose automatically.
-
-```python
-from pydantic_ai import Agent
-from pydantic_ai.capabilities import Thinking, WebSearch
-
-# Built-in capabilities: just pass instances
-agent = Agent(
-    'anthropic:claude-opus-4-6',
-    capabilities=[
-        Thinking(effort='high'),
-        WebSearch(),
-    ],
-)
-```
-
-**WebSearch** auto-detects whether the model supports builtin web search. If so, it uses the native tool; otherwise, it falls back to a local implementation (e.g., DuckDuckGo). Same pattern applies to `WebFetch`, `ImageGeneration`, and `MCP`.
-
-**Docs:** [Capabilities](https://ai.pydantic.dev/capabilities/) · [Built-in Capabilities](https://ai.pydantic.dev/capabilities/#built-in-capabilities)
-
----
+Read [Add Capabilities](./CAPABILITIES-AND-HOOKS.md#add-capabilities-to-an-agent).
 
 ## Intercept Agent Lifecycle with Hooks
 
-Use `Hooks` for lightweight lifecycle interception via decorators. For reusable behavior that combines hooks with tools/instructions, subclass `AbstractCapability` instead.
-
-```python
-from pydantic_ai import Agent, RunContext
-from pydantic_ai.capabilities.hooks import Hooks
-from pydantic_ai.models import ModelRequestContext
-
-hooks = Hooks()
-
-
-@hooks.on.before_model_request
-async def log_request(ctx: RunContext[None], request_context: ModelRequestContext) -> ModelRequestContext:
-    print(f'Sending {len(request_context.messages)} messages')
-    return request_context
-
-
-@hooks.on.before_tool_execute(tools=['send_email'])
-async def audit_tool(ctx, *, call, tool_def, args):
-    print(f'Executing {call.tool_name}')
-    return args
-
-
-agent = Agent('openai:gpt-5.2', capabilities=[hooks])
-```
-
-**Hook types:** `before_run`/`after_run`, `run` (wrap), `run_error`, `before_node_run`/`after_node_run`, `node_run` (wrap), `node_run_error`, `before_model_request`/`after_model_request`, `model_request` (wrap), `model_request_error`, `before_tool_validate`/`after_tool_validate`, `tool_validate` (wrap), `tool_validate_error`, `before_tool_execute`/`after_tool_execute`, `tool_execute` (wrap), `tool_execute_error`, `prepare_tools`, `run_event_stream`, `event`.
-
-**Docs:** [Hooks](https://ai.pydantic.dev/hooks/) · [Hooking into the Lifecycle](https://ai.pydantic.dev/capabilities/#hooking-into-the-lifecycle)
-
----
+Read [Intercept Agent Lifecycle with Hooks](./CAPABILITIES-AND-HOOKS.md#intercept-agent-lifecycle-with-hooks).
 
 ## Define Agents Declaratively with Specs
 
-Use YAML/JSON specs to separate agent configuration from application code. Specs support template strings rendered from dependencies at runtime.
-
-```yaml
-# agent.yaml
-model: anthropic:claude-opus-4-6
-instructions: "You are helping {{user_name}} with research."
-capabilities:
-  - WebSearch
-  - Thinking:
-      effort: high
-model_settings:
-  max_tokens: 8192
-```
-
-```python
-from dataclasses import dataclass
-
-from pydantic_ai import Agent
-
-
-@dataclass
-class UserContext:
-    user_name: str
-
-
-agent = Agent.from_file('agent.yaml', deps_type=UserContext)
-result = agent.run_sync('Find recent papers on AI safety', deps=UserContext(user_name='Alice'))
-```
-
-**Capability spec syntax:** `'WebSearch'` (no args), `{'Thinking': {'effort': 'high'}}` (kwargs), `{'Thinking': 'high'}` (single arg).
-
-**Docs:** [Agent Specs](https://ai.pydantic.dev/agent-spec/) · [Template Strings](https://ai.pydantic.dev/agent-spec/#template-strings)
-
----
+Read [Define Agents Declaratively with Specs](./AGENTS-CORE.md#define-agents-declaratively-with-specs).
 
 ## Enable Thinking Across Providers
 
-Use the unified `Thinking` capability or `thinking` model setting for cross-provider reasoning support.
+Read [Enable Thinking Across Providers](./CAPABILITIES-AND-HOOKS.md#enable-thinking-across-providers).
 
-```python
-from pydantic_ai import Agent
-from pydantic_ai.capabilities import Thinking
+## Use MCP Servers
 
-# Via capability (recommended for spec compatibility)
-agent = Agent('anthropic:claude-opus-4-6', capabilities=[Thinking(effort='high')])
+Read [Use MCP Servers](./TOOLS-CORE.md#use-mcp-servers).
 
-# Via model_settings (equivalent)
-agent = Agent('anthropic:claude-opus-4-6', model_settings={'thinking': 'high'})
-```
+## Search with DuckDuckGo, Tavily, or Exa
 
-**Effort levels:** `True` (default effort), `False` (disable), `'minimal'`, `'low'`, `'medium'`, `'high'`, `'xhigh'`. Automatically mapped to each provider's native format (Anthropic adaptive thinking, OpenAI reasoning_effort, Google thinking_level, etc.).
+Read [Search with DuckDuckGo, Tavily, or Exa](./TOOLS-CORE.md#search-with-duckduckgo-tavily-or-exa).
 
-**Docs:** [Thinking](https://ai.pydantic.dev/thinking/) · [Unified Thinking Settings](https://ai.pydantic.dev/thinking/#unified-thinking-settings)
+## Require Tool Approval (Human in the Loop)
 
----
+Read [Require Tool Approval](./TOOLS-ADVANCED.md#require-tool-approval-human-in-the-loop).
+
+## Send Images, Audio, Video, or Documents to the Model
+
+Read [Send Images, Audio, Video, or Documents to the Model](./INPUT-AND-HISTORY.md#send-images-audio-video-or-documents-to-the-model).
 
 ## Manage Context Size
 
-Use `history_processors` to trim or filter messages before each model request.
+Read [Manage Context Size](./INPUT-AND-HISTORY.md#manage-context-size).
 
-```python
-from pydantic_ai import Agent, ModelMessage
+## Work with Message History
 
-
-async def keep_recent(messages: list[ModelMessage]) -> list[ModelMessage]:
-    return messages[-10:] if len(messages) > 10 else messages
-
-
-agent = Agent('openai:gpt-5.2', history_processors=[keep_recent])
-```
-
-**Also use for:** Privacy filtering (remove PII), summarizing old messages, role-based access.
-
-**Docs:** [Processing Message History](https://ai.pydantic.dev/message-history/#processing-message-history) · [Summarize Old Messages](https://ai.pydantic.dev/message-history/#summarize-old-messages)
-
----
+Read [Work with Message History](./INPUT-AND-HISTORY.md#work-with-message-history).
 
 ## Show Real-Time Progress
 
-Use `event_stream_handler` with `run()` or `run_stream()` to receive events as they happen.
-
-```python
-from collections.abc import AsyncIterable
-
-from pydantic_ai import Agent, AgentStreamEvent, FunctionToolCallEvent, RunContext
-
-agent = Agent('openai:gpt-5.2')
-
-
-async def stream_handler(ctx: RunContext, events: AsyncIterable[AgentStreamEvent]):
-    async for event in events:
-        if isinstance(event, FunctionToolCallEvent):
-            print(f'Calling {event.part.tool_name}...')
-
-
-async def main():
-    await agent.run('Do the task', event_stream_handler=stream_handler)
-```
-
-**Also use for:** Logging, analytics, debugging, progress bars in UIs.
-
-**Docs:** [Streaming Events and Final Output](https://ai.pydantic.dev/agents/#streaming-events-and-final-output) · [Streaming All Events](https://ai.pydantic.dev/agents/#streaming-all-events)
-
----
+Read [Run Methods and Streaming](./AGENTS-CORE.md#run-methods-and-streaming).
 
 ## Handle Provider Failures
 
-Use `FallbackModel` to automatically switch providers on 4xx/5xx errors.
+Read [Handle Provider Failures](./AGENTS-CORE.md#handle-provider-failures).
 
-```python
-from pydantic_ai import Agent
-from pydantic_ai.models.anthropic import AnthropicModel
-from pydantic_ai.models.fallback import FallbackModel
-from pydantic_ai.models.openai import OpenAIChatModel
+## Make an Agent Resilient with Retries
 
-fallback = FallbackModel(
-    OpenAIChatModel('gpt-5.2'),
-    AnthropicModel('claude-sonnet-4-6'),
-)
-agent = Agent(fallback)
-```
+Read [Make an Agent Resilient with Retries](./TOOLS-ADVANCED.md#make-an-agent-resilient-with-retries).
 
-**Also use for:** Cost optimization (expensive → cheap), rate limit handling, regional failover.
+## Debug a Failed Agent Run
 
-**Docs:** [Fallback Model](https://ai.pydantic.dev/models/#fallback-model) · [Per-Model Settings](https://ai.pydantic.dev/models/#per-model-settings)
-
----
+Read [Debug a Failed Agent Run](./TESTING-AND-DEBUGGING.md#debug-a-failed-agent-run).
 
 ## Test Agent Behavior
 
-Use `TestModel` for fast deterministic tests; `FunctionModel` for custom response logic.
-
-```python
-from pydantic_ai import Agent
-from pydantic_ai.models.test import TestModel
-
-agent = Agent('openai:gpt-5.2')
-
-# TestModel: fast, auto-generates valid responses based on schema
-with agent.override(model=TestModel()):
-    result = agent.run_sync('test prompt')
-    assert result.output == 'success (no tool calls)'
-```
-
-```python
-from pydantic_ai import Agent, ModelResponse, TextPart
-from pydantic_ai.models.function import FunctionModel
-
-agent = Agent('openai:gpt-5.2')
-
-
-# FunctionModel: capture requests, return custom responses
-def custom_model(messages, info):
-    return ModelResponse(parts=[TextPart(content='mocked response')])
-
-
-with agent.override(model=FunctionModel(custom_model)):
-    result = agent.run_sync('test prompt')
-```
-
-**Also use for:** Capturing requests for assertions, simulating errors, testing retries.
-
-**Docs:** [Unit testing with TestModel](https://ai.pydantic.dev/testing/#unit-testing-with-testmodel) · [Unit testing with FunctionModel](https://ai.pydantic.dev/testing/#unit-testing-with-functionmodel)
-
----
+Read [Test Agent Behavior](./TESTING-AND-DEBUGGING.md#test-agent-behavior).
 
 ## Coordinate Multiple Agents
 
-Use **agent delegation** (via tools) when a child returns results to parent; **output functions** for permanent hand-offs.
+Read [Coordinate Multiple Agents](./ORCHESTRATION-AND-INTEGRATIONS.md#coordinate-multiple-agents).
 
-```python
-from pydantic_ai import Agent, RunContext
+## Build Multi-Step Workflows with Graphs
 
-parent = Agent('openai:gpt-5.2')
-researcher = Agent('openai:gpt-5.2', output_type=str)
-
-@parent.tool
-async def research(ctx: RunContext, topic: str) -> str:
-    """Delegate research to specialist."""
-    result = await researcher.run(f'Research: {topic}', usage=ctx.usage)
-    return result.output
-```
-
-**Also use for:** Triage/routing, specialist hand-off, graph-based workflows.
-
-**Docs:** [Agent Delegation](https://ai.pydantic.dev/multi-agent-applications/#agent-delegation) · [Programmatic Agent Hand-off](https://ai.pydantic.dev/multi-agent-applications/#programmatic-agent-hand-off)
-
----
+Read [Build Multi-Step Workflows with Graphs](./ORCHESTRATION-AND-INTEGRATIONS.md#build-multi-step-workflows-with-graphs).
 
 ## Debug and Validate Agent Behavior
 
-Instrument with [Logfire](https://logfire.pydantic.dev/) to see exact model requests, tool calls, and validate LLM outputs. Each agent run becomes a parent trace with child spans for every tool call and LLM request.
+Read [Debug and Validate Agent Behavior](./TESTING-AND-DEBUGGING.md#debug-and-validate-agent-behavior).
 
-```python
-import logfire
+## Advanced and Less Common Features
 
-logfire.configure()
-logfire.instrument_pydantic_ai()
+Read only the relevant section in [ORCHESTRATION-AND-INTEGRATIONS.md](./ORCHESTRATION-AND-INTEGRATIONS.md):
 
-# All agent runs now traced — see tool calls, model requests, and outputs in Logfire dashboard
-```
+- [Direct API](./ORCHESTRATION-AND-INTEGRATIONS.md#call-the-model-without-using-an-agent)
+- [A2A](./ORCHESTRATION-AND-INTEGRATIONS.md#expose-agents-as-http-servers-a2a)
+- [Durable Execution](./ORCHESTRATION-AND-INTEGRATIONS.md#use-durable-execution)
+- [Embeddings](./ORCHESTRATION-AND-INTEGRATIONS.md#use-embeddings-for-rag)
+- [Third-Party Tools](./ORCHESTRATION-AND-INTEGRATIONS.md#use-langchain-or-acidev-tools)
+- [Custom Extensibility](./ORCHESTRATION-AND-INTEGRATIONS.md#build-custom-toolsets-models-or-agents)
+- [Evals](./ORCHESTRATION-AND-INTEGRATIONS.md#systematically-verify-agent-behavior-with-evals)
 
-For full HTTP-level visibility into what's sent to model providers (invaluable for debugging tool schema errors or unexpected model behavior):
+## Working with the Installed Pydantic AI Package
 
-```python
-logfire.instrument_httpx(capture_all=True)
-```
+Prefer the checked-out repository or these bundled references first.
 
-**Use for:** Debugging unexpected behavior, validating tool schemas, understanding what's sent to providers, production monitoring.
+Inspect local package source only as a last resort when:
 
-**Docs:** [Using Logfire](https://ai.pydantic.dev/logfire/#using-logfire) · [Monitoring HTTP Requests](https://ai.pydantic.dev/logfire/#monitoring-http-requests)
+- the user asks about a symbol that is not covered in this skill
+- the local environment already includes `pydantic_ai` and you need exact module layout
+- you have no narrower offline reference available

--- a/plugins/ai/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
+++ b/plugins/ai/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
@@ -1,0 +1,66 @@
+# Input and History
+
+Read this file when the user wants multimodal input, message history, or context trimming.
+
+## Send Images, Audio, Video, or Documents to the Model
+
+Pass multimodal content as a list mixing text with `ImageUrl`, `AudioUrl`, `VideoUrl`, `DocumentUrl`, or `BinaryContent`.
+
+```python
+from pydantic_ai import Agent, ImageUrl
+
+agent = Agent(model='openai:gpt-5.2')
+result = agent.run_sync(
+    [
+        'What company is this logo from?',
+        ImageUrl(url='https://example.com/logo.png'),
+    ]
+)
+print(result.output)
+```
+
+Use `BinaryContent(...)` when the asset is already in memory instead of at a URL.
+
+Not every model supports every input type. Keep provider expectations in mind when the user chooses a specific model.
+
+## Work with Message History
+
+Use `message_history=` to continue a conversation across runs.
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2', instructions='Be a helpful assistant.')
+
+result1 = agent.run_sync('Tell me a joke.')
+result2 = agent.run_sync('Explain?', message_history=result1.new_messages())
+print(result2.output)
+```
+
+Important distinctions:
+
+- `new_messages()` returns only the current run
+- `all_messages()` returns the full history accumulated so far
+- when `message_history` is non-empty, Pydantic AI assumes the history already carries the system prompt
+
+## Manage Context Size
+
+Use `history_processors=[...]` to trim or rewrite message history before each model request.
+
+```python
+from pydantic_ai import Agent, ModelMessage
+
+
+async def keep_recent(messages: list[ModelMessage]) -> list[ModelMessage]:
+    return messages[-10:] if len(messages) > 10 else messages
+
+
+agent = Agent('openai:gpt-5.2', history_processors=[keep_recent])
+```
+
+Good uses:
+
+- trimming long conversations
+- removing PII before provider calls
+- summarizing old messages
+- applying app-specific history policies

--- a/plugins/ai/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
+++ b/plugins/ai/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
@@ -1,0 +1,129 @@
+# Orchestration and Integrations
+
+Read this file when the user wants multi-agent coordination, graphs, direct model calls, A2A, durable execution, embeddings, evals, or third-party integrations.
+
+## Coordinate Multiple Agents
+
+Use agent delegation when one agent should call another and return the result.
+
+```python
+from pydantic_ai import Agent, RunContext
+
+parent = Agent('openai:gpt-5.2')
+researcher = Agent('openai:gpt-5.2', output_type=str)
+
+
+@parent.tool
+async def research(ctx: RunContext[None], topic: str) -> str:
+    result = await researcher.run(f'Research: {topic}', usage=ctx.usage)
+    return result.output
+```
+
+Good split:
+
+- delegation via tools when the parent keeps control
+- output functions or programmatic hand-off when control should move elsewhere
+
+## Build Multi-Step Workflows with Graphs
+
+Use `pydantic_graph` when the workflow is a state machine rather than a single agent loop.
+
+```python
+from dataclasses import dataclass
+
+from pydantic_graph import BaseNode, End, Graph, GraphRunContext
+
+
+@dataclass
+class FirstNode(BaseNode[None, None, int]):
+    value: int
+
+    async def run(self, ctx: GraphRunContext) -> 'SecondNode | End[int]':
+        if self.value >= 5:
+            return End(self.value)
+        return SecondNode(self.value + 1)
+
+
+@dataclass
+class SecondNode(BaseNode):
+    value: int
+
+    async def run(self, ctx: GraphRunContext) -> FirstNode:
+        return FirstNode(self.value)
+
+
+graph = Graph(nodes=[FirstNode, SecondNode])
+result = graph.run_sync(FirstNode(0))
+```
+
+## Call the Model Without Using an Agent
+
+Use the direct API when the user wants a single model request without agent orchestration.
+
+```python
+from pydantic_ai.direct import model_request_sync
+```
+
+Reach for this when there is no need for tools, retries, or agent loop state.
+
+## Expose Agents as HTTP Servers (A2A)
+
+Use `agent.to_a2a()` when the agent should be exposed as an ASGI app that speaks the A2A protocol.
+
+```python
+app = agent.to_a2a()
+```
+
+## Use Durable Execution
+
+Use the durable execution integrations when the run must survive crashes, retries, or long-lived workflows.
+
+Temporal entry points:
+
+- `TemporalAgent`
+- `PydanticAIWorkflow`
+- `PydanticAIPlugin`
+
+There are parallel integrations for DBOS and Prefect.
+
+## Use Embeddings for RAG
+
+Use `Embedder(...)` for query/document embeddings when the user is building retrieval or semantic search.
+
+```python
+from pydantic_ai import Embedder
+
+embedder = Embedder('openai:text-embedding-3-small')
+```
+
+## Use LangChain or ACI.dev Tools
+
+Third-party integrations to reach for:
+
+- `tool_from_langchain`
+- `LangChainToolset`
+- `tool_from_aci`
+- `ACIToolset`
+
+Use these when the user explicitly wants those ecosystems instead of native Pydantic AI tools.
+
+## Systematically Verify Agent Behavior with Evals
+
+Use `pydantic_evals` when the user wants repeatable evaluation datasets and evaluators rather than ad hoc tests.
+
+Common entry points:
+
+- `Case`
+- `Dataset`
+- evaluator classes from `pydantic_evals.evaluators`
+
+## Build Custom Toolsets, Models, or Agents
+
+Extensibility entry points:
+
+- `AbstractToolset` / `WrapperToolset`
+- `Model` / `WrapperModel`
+- `AbstractAgent` / `WrapperAgent`
+- `AbstractCapability`
+
+Reach for these only when the built-in primitives are genuinely insufficient.

--- a/plugins/ai/skills/building-pydantic-ai-agents/references/TESTING-AND-DEBUGGING.md
+++ b/plugins/ai/skills/building-pydantic-ai-agents/references/TESTING-AND-DEBUGGING.md
@@ -1,0 +1,75 @@
+# Testing and Debugging
+
+Read this file when the user wants deterministic tests, custom test models, request inspection, or runtime debugging.
+
+## Test Agent Behavior
+
+Use `TestModel` for fast deterministic tests and `FunctionModel` for custom response logic.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+agent = Agent('openai:gpt-5.2')
+
+with agent.override(model=TestModel()):
+    result = agent.run_sync('test prompt')
+    assert result.output == 'success (no tool calls)'
+```
+
+```python
+from pydantic_ai import Agent, ModelResponse, TextPart
+from pydantic_ai.models.function import FunctionModel
+
+agent = Agent('openai:gpt-5.2')
+
+
+def custom_model(messages, info):
+    return ModelResponse(parts=[TextPart(content='mocked response')])
+
+
+with agent.override(model=FunctionModel(custom_model)):
+    result = agent.run_sync('test prompt')
+```
+
+Default split:
+
+- `TestModel` when you want automatic valid outputs
+- `FunctionModel` when you need exact behavior for assertions, failures, or retries
+
+## Debug a Failed Agent Run
+
+Use `capture_run_messages()` when the user needs the exact request/response history that led to a failure.
+
+```python
+from pydantic_ai import Agent, UnexpectedModelBehavior, capture_run_messages
+
+agent = Agent('openai:gpt-5.2')
+
+with capture_run_messages() as messages:
+    try:
+        agent.run_sync('Please get me the volume of a box with size 6.')
+    except UnexpectedModelBehavior:
+        print(messages)
+```
+
+Use this for in-process debugging. It is a better fit than broad logging when the user wants to inspect one failing run.
+
+## Debug and Validate Agent Behavior
+
+Use Logfire when the user wants observability across agent runs, tools, and model requests.
+
+```python
+import logfire
+
+logfire.configure()
+logfire.instrument_pydantic_ai()
+logfire.instrument_httpx(capture_all=True)
+```
+
+Good uses:
+
+- tracing tool calls
+- validating what was sent to the provider
+- understanding structured-output failures
+- production observability

--- a/plugins/ai/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
+++ b/plugins/ai/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
@@ -1,0 +1,133 @@
+# Tools Advanced
+
+Read this file when the user wants advanced tool behavior: approval, retries, validation, timeouts, rich tool returns, or tool search/deferred loading.
+
+## Require Tool Approval (Human in the Loop)
+
+Use deferred tools when the run should pause for approval.
+
+```python
+from pydantic_ai import (
+    Agent,
+    DeferredToolRequests,
+    DeferredToolResults,
+    ToolDenied,
+)
+
+agent = Agent('openai:gpt-5.2', output_type=[str, DeferredToolRequests])
+
+
+@agent.tool_plain(requires_approval=True)
+def delete_file(path: str) -> str:
+    return f'File {path!r} deleted'
+
+
+result = agent.run_sync('Delete __init__.py')
+messages = result.all_messages()
+
+assert isinstance(result.output, DeferredToolRequests)
+results = DeferredToolResults()
+for call in result.output.approvals:
+    results.approvals[call.tool_call_id] = ToolDenied('Deleting files is not allowed')
+
+result = agent.run_sync('Continue', message_history=messages, deferred_tool_results=results)
+print(result.output)
+```
+
+Two key rules:
+
+- `DeferredToolRequests` must be in the output type
+- for conditional approval, raise `ApprovalRequired(...)` instead of marking the whole tool `requires_approval=True`
+
+## Make an Agent Resilient with Retries
+
+Raise `ModelRetry` from inside the tool when the model should correct and try again.
+
+```python
+from pydantic_ai import Agent, ModelRetry, RunContext
+
+agent = Agent('openai:gpt-5.2', deps_type=dict[str, int])
+
+
+@agent.tool(retries=2)
+def get_user_by_name(ctx: RunContext[dict[str, int]], name: str) -> int:
+    user_id = ctx.deps.get(name)
+    if user_id is None:
+        raise ModelRetry(f'No user found with name {name!r}')
+    return user_id
+```
+
+Use retries for recoverable model mistakes, not application crashes.
+
+## Validate or Require Approval Before Tool Execution
+
+Use `args_validator=` when arguments are structurally valid but still need business-rule validation before execution or approval.
+
+```python
+from pydantic_ai import Agent, DeferredToolRequests, ModelRetry, RunContext
+
+agent = Agent('openai:gpt-5.2', deps_type=int, output_type=[str, DeferredToolRequests])
+
+
+def validate_sum_limit(ctx: RunContext[int], x: int, y: int) -> None:
+    if x + y > ctx.deps:
+        raise ModelRetry(f'Sum of x and y must not exceed {ctx.deps}')
+
+
+@agent.tool(requires_approval=True, args_validator=validate_sum_limit)
+def add_numbers(ctx: RunContext[int], x: int, y: int) -> int:
+    return x + y
+```
+
+## Use Advanced Tool Features
+
+Reach for these features when the user needs more than a simple function tool:
+
+- `ToolReturn` for rich return values plus separate content/metadata
+- `prepare=` for dynamic tool definitions
+- `timeout=` for tool execution limits
+- `sequential=True` when tool calls must not run concurrently
+
+Example with `ToolReturn`:
+
+```python
+from pydantic_ai import Agent, BinaryContent, ToolReturn
+
+agent = Agent('openai:gpt-5.2')
+
+
+@agent.tool_plain
+def click_and_capture(x: int, y: int) -> ToolReturn:
+    return ToolReturn(
+        return_value=f'Successfully clicked at ({x}, {y})',
+        content=['After:', BinaryContent(data=b'png-data', media_type='image/png')],
+        metadata={'coordinates': {'x': x, 'y': y}},
+    )
+```
+
+## Handle Network Errors and Rate Limiting Automatically
+
+For tool-call retries, use `ModelRetry` and tool `retries=...`.
+
+For HTTP request retries at the transport layer, use the library's retry configuration separately. Do not assume `ModelRetry` alone solves provider transport failures.
+
+## Tool Search and Deferred Loading
+
+Use deferred loading when the agent has many tools and the model should discover them on demand via `search_tools`.
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+
+
+@agent.tool_plain(defer_loading=True)
+def lookup_internal_policy(policy_name: str) -> str:
+    return f'policy details for {policy_name}'
+```
+
+Good fit:
+
+- large MCP servers
+- big tool catalogs
+- situations where loading all tool schemas would bloat context

--- a/plugins/ai/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
+++ b/plugins/ai/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
@@ -1,0 +1,102 @@
+# Tools Core
+
+Read this file when the user wants to add function tools, organize toolsets, connect MCP servers, or use explicit common search tools.
+
+## Add Tools to an Agent
+
+Use `@agent.tool_plain` for pure functions and `@agent.tool` for tools that need `RunContext`.
+
+```python
+import random
+
+from pydantic_ai import Agent, RunContext
+
+agent = Agent('google-gla:gemini-3-flash-preview', deps_type=str)
+
+
+@agent.tool_plain
+def roll_dice() -> str:
+    return str(random.randint(1, 6))
+
+
+@agent.tool
+def get_player_name(ctx: RunContext[str]) -> str:
+    return ctx.deps
+```
+
+Use `Tool(fn)` when tools are defined outside the agent file or shared between agents.
+
+## Choosing a Tool Registration Method
+
+Default choices:
+
+- `@agent.tool` when the tool needs deps, usage, retry count, or message history
+- `@agent.tool_plain` when the tool is a plain function
+- `Tool(...)` in `tools=[...]` when the tool should be reusable across agents
+- `FunctionToolset` when multiple related tools should be managed as a group
+
+## Organize or Restrict Which Tools an Agent Can Use
+
+Use toolsets when the user has multiple related tools or wants cross-cutting behavior applied to a group.
+
+Examples:
+
+- `FunctionToolset` for a bundle of Python tools
+- MCP servers, which are themselves toolsets
+- wrapper toolsets for approval, deferred loading, or other cross-cutting behavior
+
+## Access Usage Stats, Message History, or Retry Count in Tools
+
+Route this to `@agent.tool` with `RunContext`.
+
+Useful `RunContext` fields include:
+
+- `ctx.deps`
+- `ctx.usage`
+- `ctx.messages`
+- `ctx.retry`
+
+## Use MCP Servers
+
+Attach an MCP server as a toolset on the agent.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPServerStdio
+
+server = MCPServerStdio('python', args=['mcp_server.py'], timeout=10)
+agent = Agent('openai:gpt-5.2', toolsets=[server])
+
+
+async def main():
+    async with agent:
+        result = await agent.run('What is the weather in Paris?')
+        print(result.output)
+```
+
+Default transport choices:
+
+- `MCPServerStdio` for local subprocess servers
+- `MCPServerStreamableHTTP` for HTTP servers
+
+`MCPServerSSE` still exists, but Streamable HTTP is the better default.
+
+## Search with DuckDuckGo, Tavily, or Exa
+
+Use common tools when the user wants explicit search tools rather than provider-adaptive capabilities.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.common_tools.duckduckgo import duckduckgo_search_tool
+
+agent = Agent(
+    'openai:gpt-5.2',
+    tools=[duckduckgo_search_tool()],
+    instructions='Search DuckDuckGo for the given query and return the results.',
+)
+```
+
+Good default split:
+
+- use `WebSearch()` capability when the user wants model-agnostic search with builtin fallback
+- use `duckduckgo_search_tool()` / Tavily / Exa when the user explicitly wants those engines as tools

--- a/scripts/check-skill-sync.sh
+++ b/scripts/check-skill-sync.sh
@@ -58,4 +58,36 @@ check_sync \
     plugins/ai/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md \
     skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
 
+check_sync \
+    plugins/ai/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md \
+    skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
+
+check_sync \
+    plugins/ai/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md \
+    skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
+
+check_sync \
+    plugins/ai/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md \
+    skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
+
+check_sync \
+    plugins/ai/skills/building-pydantic-ai-agents/references/BUILTIN-TOOLS.md \
+    skills/building-pydantic-ai-agents/references/BUILTIN-TOOLS.md
+
+check_sync \
+    plugins/ai/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md \
+    skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
+
+check_sync \
+    plugins/ai/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md \
+    skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
+
+check_sync \
+    plugins/ai/skills/building-pydantic-ai-agents/references/TESTING-AND-DEBUGGING.md \
+    skills/building-pydantic-ai-agents/references/TESTING-AND-DEBUGGING.md
+
+check_sync \
+    plugins/ai/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md \
+    skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
+
 exit $exit_code

--- a/skills/building-pydantic-ai-agents/SKILL.md
+++ b/skills/building-pydantic-ai-agents/SKILL.md
@@ -7,7 +7,7 @@ description: >
 license: MIT
 compatibility: Requires Python 3.10+
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   author: pydantic
 ---
 
@@ -212,58 +212,25 @@ agent = Agent.from_file('agent.yaml')
 
 ## Task Routing Table
 
+Load only the most relevant reference first. Read additional references only if the task spans multiple areas.
+
 | I want to... | Reference |
 |---|---|
-| Create or configure agents | [Create a Basic Agent](#create-a-basic-agent) |
-| Bundle reusable behavior (tools, hooks, instructions) | [Add Capabilities to an Agent](./references/COMMON-TASKS.md#add-capabilities-to-an-agent) |
-| Intercept model requests, tool calls, or runs | [Intercept Agent Lifecycle with Hooks](./references/COMMON-TASKS.md#intercept-agent-lifecycle-with-hooks) |
-| Define agents in YAML/JSON without Python code | [Define Agents Declaratively with Specs](./references/COMMON-TASKS.md#define-agents-declaratively-with-specs) |
-| Use template strings in agent instructions | [Define Agents Declaratively with Specs](./references/COMMON-TASKS.md#define-agents-declaratively-with-specs) |
-| Let my agent call external APIs or functions | [Add Tools to an Agent](#add-tools-to-an-agent) |
-| Organize or restrict which tools an agent can use | [Choosing a Tool Registration Method](./references/ARCHITECTURE.md#choosing-a-tool-registration-method) |
-| Give my agent web search with automatic provider fallback | [Add Capabilities to an Agent](./references/COMMON-TASKS.md#add-capabilities-to-an-agent) |
-| Give my agent URL fetching with automatic provider fallback | [Add Capabilities to an Agent](./references/COMMON-TASKS.md#add-capabilities-to-an-agent) |
-| Give my agent web search or code execution (builtin tools) | [Add Capabilities to an Agent](./references/COMMON-TASKS.md#add-capabilities-to-an-agent) |
-| Search with DuckDuckGo/Tavily/Exa | [Search with DuckDuckGo, Tavily, or Exa](./references/COMMON-TASKS.md#search-with-duckduckgo-tavily-or-exa) |
-| Ensure my agent returns data in a specific format | [Structured Output with Pydantic Models](#structured-output-with-pydantic-models) |
-| Pass database connections, API clients, or config to tools | [Dependency Injection](#dependency-injection) |
-| Access usage stats, message history, or retry count in tools | [Add Tools to an Agent](#add-tools-to-an-agent) |
-| Choose or configure models | [Model Provider Prefixes](./references/ARCHITECTURE.md#model-provider-prefixes) |
-| Automatically switch to backup model when primary fails | [Handle Provider Failures](./references/COMMON-TASKS.md#handle-provider-failures) |
-| Show real-time progress as my agent works | [Show Real-Time Progress](./references/COMMON-TASKS.md#show-real-time-progress) |
-| Work with messages and multimedia | [Work with Message History](./references/COMMON-TASKS.md#work-with-message-history) |
-| Reduce token costs by trimming or filtering conversation history | [Manage Context Size](./references/COMMON-TASKS.md#manage-context-size) |
-| Keep long conversations manageable without losing context | [Manage Context Size](./references/COMMON-TASKS.md#manage-context-size) |
-| Use MCP servers | [Use MCP Servers](./references/COMMON-TASKS.md#use-mcp-servers) |
-| Build multi-step graphs | [Build Multi-Step Workflows with Graphs](./references/COMMON-TASKS.md#build-multi-step-workflows-with-graphs) |
-| Debug a failed agent run or see what went wrong | [Debug a Failed Agent Run](./references/COMMON-TASKS.md#debug-a-failed-agent-run) |
-| Make my agent resilient to temporary failures | [Make an Agent Resilient with Retries](./references/COMMON-TASKS.md#make-an-agent-resilient-with-retries) |
-| Understand why my agent made specific decisions | [Debug and Validate Agent Behavior](./references/COMMON-TASKS.md#debug-and-validate-agent-behavior) |
-| Write deterministic tests for my agent | [Test Agent Behavior](./references/COMMON-TASKS.md#test-agent-behavior) |
-| Enable thinking/reasoning across any provider | [Enable Thinking Across Providers](./references/COMMON-TASKS.md#enable-thinking-across-providers) |
-| Systematically verify my agent works correctly | [Evaluations (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
-| Use embeddings for RAG | [Embeddings (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
-| Use durable execution | [Durable Execution (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
-| Have one agent delegate tasks to another | [Coordinate Multiple Agents](./references/COMMON-TASKS.md#coordinate-multiple-agents) |
-| Route requests to different agents based on intent | [Coordinate Multiple Agents](./references/COMMON-TASKS.md#coordinate-multiple-agents) |
-| Require tool approval (human-in-the-loop) | [Require Tool Approval (Human in the Loop)](./references/COMMON-TASKS.md#require-tool-approval-human-in-the-loop) |
-| Use images, audio, video, or documents | [Send Images, Audio, Video, or Documents to the Model](./references/COMMON-TASKS.md#send-images-audio-video-or-documents-to-the-model) |
-| Use advanced tool features | [Require Tool Approval (Human in the Loop)](./references/COMMON-TASKS.md#require-tool-approval-human-in-the-loop) |
-| Validate or require approval before tool execution | [Require Tool Approval (Human in the Loop)](./references/COMMON-TASKS.md#require-tool-approval-human-in-the-loop) |
-| Call the model without using an agent | [Direct API (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
-| Expose agents as HTTP servers (A2A) | [A2A (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
-| Handle network errors and rate limiting automatically | [Make an Agent Resilient with Retries](./references/COMMON-TASKS.md#make-an-agent-resilient-with-retries) |
-| Use LangChain or ACI.dev tools | [Third-Party Tools (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
-| Publish reusable agent extensions as packages | [Custom Toolsets/Models/Capabilities (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
-| Build custom toolsets, models, or agents | [Custom Toolsets/Models/Capabilities (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
-| Debug common issues | [Debug a Failed Agent Run](./references/COMMON-TASKS.md#debug-a-failed-agent-run) |
-| Migrate from deprecated APIs | [Working with the Installed Pydantic AI Package](./references/COMMON-TASKS.md#working-with-the-installed-pydantic-ai-package) |
-| See advanced real-world examples | [Working with the Installed Pydantic AI Package](./references/COMMON-TASKS.md#working-with-the-installed-pydantic-ai-package) |
-| Look up an import path | [Working with the Installed Pydantic AI Package](./references/COMMON-TASKS.md#working-with-the-installed-pydantic-ai-package) |
+| Create/configure agents, choose output types, use deps, define specs, or pick run methods | [Agents Core](./references/AGENTS-CORE.md) |
+| Bundle reusable behavior or intercept lifecycle events | [Capabilities and Hooks](./references/CAPABILITIES-AND-HOOKS.md) |
+| Add function tools, toolsets, MCP servers, or explicit search tools | [Tools Core](./references/TOOLS-CORE.md) |
+| Use provider-native web search, web fetch, or code execution | [Built-in Tools](./references/BUILTIN-TOOLS.md) |
+| Use advanced tool features such as approval, retries, `ToolReturn`, validators, timeouts, or tool search | [Tools Advanced](./references/TOOLS-ADVANCED.md) |
+| Work with multimodal input, message history, or context trimming | [Input and History](./references/INPUT-AND-HISTORY.md) |
+| Test or debug agent behavior | [Testing and Debugging](./references/TESTING-AND-DEBUGGING.md) |
+| Coordinate multiple agents or build graph workflows | [Orchestration and Integrations](./references/ORCHESTRATION-AND-INTEGRATIONS.md#coordinate-multiple-agents) |
+| Call the model directly, expose A2A, use durable execution, embeddings, evals, or third-party integrations | [Orchestration and Integrations](./references/ORCHESTRATION-AND-INTEGRATIONS.md) |
+| Compare abstractions, output modes, decorators, or model-string patterns | [Architecture and Decision Guide](./references/ARCHITECTURE.md) |
+| Follow an older link into `COMMON-TASKS.md` | [Task Reference Map](./references/COMMON-TASKS.md) |
 
 ## Architecture and Decisions
 
-Load [Architecture and Decision Guide](./references/ARCHITECTURE.md) for detailed decision trees, comparison tables, and architecture overview:
+Load [Architecture and Decision Guide](./references/ARCHITECTURE.md) only when the user is choosing between abstractions or wants comparison tables and decision trees:
 
 | Topic | What it covers |
 |---|---|
@@ -292,19 +259,19 @@ These are mistakes agents commonly make with Pydantic AI. Getting these wrong pr
 - **Hook decorator names on `.on` don't repeat `on_`**: Use `hooks.on.run_error` and `hooks.on.model_request_error` — not `hooks.on.on_run_error`.
 - **`history_processors` is plural**: The Agent parameter is `history_processors=[...]`, not `history_processor=`.
 
-## Common Tasks
+## Task-Family References
 
-Load [Common Tasks Reference](./references/COMMON-TASKS.md) for detailed implementation guidance with code examples:
+Load exactly one of these unless the task clearly spans multiple families:
 
-| Task | Section |
+| Task family | Reference |
 |---|---|
-| Add capabilities (Thinking, WebSearch, etc.) | Add Capabilities to an Agent |
-| Intercept model requests and tool calls | Intercept Agent Lifecycle with Hooks |
-| Define agents from YAML/JSON config files | Define Agents Declaratively with Specs |
-| Enable thinking/reasoning across providers | Enable Thinking Across Providers |
-| Trim or filter conversation history | Manage Context Size |
-| Stream events and show real-time progress | Show Real-Time Progress |
-| Auto-switch providers on failure | Handle Provider Failures |
-| Write deterministic tests | Test Agent Behavior |
-| Delegate tasks between agents | Coordinate Multiple Agents |
-| Instrument with Logfire for debugging | Debug and Validate Agent Behavior |
+| Core agent setup, output, deps, specs, models, run methods | [Agents Core](./references/AGENTS-CORE.md) |
+| Capabilities, hooks, and reusable behavior | [Capabilities and Hooks](./references/CAPABILITIES-AND-HOOKS.md) |
+| Function tools, toolsets, MCP, explicit search tools | [Tools Core](./references/TOOLS-CORE.md) |
+| Provider-native builtin tools | [Built-in Tools](./references/BUILTIN-TOOLS.md) |
+| Approval, retries, validators, timeouts, rich tool returns, deferred loading | [Tools Advanced](./references/TOOLS-ADVANCED.md) |
+| Multimodal input, message history, history processors | [Input and History](./references/INPUT-AND-HISTORY.md) |
+| Testing, request inspection, and Logfire debugging | [Testing and Debugging](./references/TESTING-AND-DEBUGGING.md) |
+| Multi-agent patterns, graphs, direct API, A2A, durable execution, embeddings, evals, third-party integrations | [Orchestration and Integrations](./references/ORCHESTRATION-AND-INTEGRATIONS.md) |
+
+Use [Task Reference Map](./references/COMMON-TASKS.md) only for compatibility with older links or when you need a pointer from an old section name to the new file.

--- a/skills/building-pydantic-ai-agents/SKILL.md
+++ b/skills/building-pydantic-ai-agents/SKILL.md
@@ -212,54 +212,54 @@ agent = Agent.from_file('agent.yaml')
 
 ## Task Routing Table
 
-| I want to... | Documentation |
+| I want to... | Reference |
 |---|---|
-| Create or configure agents | [Agents](https://ai.pydantic.dev/agents/) |
-| Bundle reusable behavior (tools, hooks, instructions) | [Capabilities](https://ai.pydantic.dev/capabilities/) |
-| Intercept model requests, tool calls, or runs | [Hooks](https://ai.pydantic.dev/hooks/) |
-| Define agents in YAML/JSON without Python code | [Agent Specs](https://ai.pydantic.dev/agent-spec/) |
-| Use template strings in agent instructions | [Template Strings](https://ai.pydantic.dev/agent-spec/#template-strings) |
-| Let my agent call external APIs or functions | [Tools](https://ai.pydantic.dev/tools/) |
-| Organize or restrict which tools an agent can use | [Toolsets](https://ai.pydantic.dev/toolsets/) |
-| Give my agent web search with automatic provider fallback | [WebSearch Capability](https://ai.pydantic.dev/capabilities/#provider-adaptive-tools) |
-| Give my agent URL fetching with automatic provider fallback | [WebFetch Capability](https://ai.pydantic.dev/capabilities/#provider-adaptive-tools) |
-| Give my agent web search or code execution (builtin tools) | [Built-in Tools](https://ai.pydantic.dev/builtin-tools/) |
-| Search with DuckDuckGo/Tavily/Exa | [Common Tools](https://ai.pydantic.dev/common-tools/) |
-| Ensure my agent returns data in a specific format | [Structured Output](https://ai.pydantic.dev/output/#structured-output) |
-| Pass database connections, API clients, or config to tools | [Dependencies](https://ai.pydantic.dev/dependencies/) |
-| Access usage stats, message history, or retry count in tools | [RunContext](https://ai.pydantic.dev/tools/) |
-| Choose or configure models | [Models](https://ai.pydantic.dev/models/) |
-| Automatically switch to backup model when primary fails | [Fallback Model](https://ai.pydantic.dev/models/#fallback-model) |
-| Show real-time progress as my agent works | [Streaming Events and Final Output](https://ai.pydantic.dev/agents/#streaming-events-and-final-output) |
-| Work with messages and multimedia | [Message History](https://ai.pydantic.dev/message-history/) |
-| Reduce token costs by trimming or filtering conversation history | [Processing Message History](https://ai.pydantic.dev/message-history/#processing-message-history) |
-| Keep long conversations manageable without losing context | [Summarize Old Messages](https://ai.pydantic.dev/message-history/#summarize-old-messages) |
-| Use MCP servers | [MCP](https://ai.pydantic.dev/mcp/) |
-| Build multi-step graphs | [Graph](https://ai.pydantic.dev/graph/) |
-| Debug a failed agent run or see what went wrong | [Model Errors](https://ai.pydantic.dev/agents/#model-errors) |
-| Make my agent resilient to temporary failures | [Retries](https://ai.pydantic.dev/retries/) |
-| Understand why my agent made specific decisions | [Using Logfire](https://ai.pydantic.dev/logfire/#using-logfire) |
-| Write deterministic tests for my agent | [Unit testing with TestModel](https://ai.pydantic.dev/testing/#unit-testing-with-testmodel) |
-| Enable thinking/reasoning across any provider | [Thinking](https://ai.pydantic.dev/thinking/) · [Thinking Capability](https://ai.pydantic.dev/capabilities/#thinking) |
-| Systematically verify my agent works correctly | [Evals](https://ai.pydantic.dev/evals/) |
-| Use embeddings for RAG | [Embeddings](https://ai.pydantic.dev/embeddings/) |
-| Use durable execution | [Durable Execution](https://ai.pydantic.dev/durable_execution/overview/) |
-| Have one agent delegate tasks to another | [Agent Delegation](https://ai.pydantic.dev/multi-agent-applications/#agent-delegation) |
-| Route requests to different agents based on intent | [Programmatic Agent Hand-off](https://ai.pydantic.dev/multi-agent-applications/#programmatic-agent-hand-off) |
-| Require tool approval (human-in-the-loop) | [Deferred Tools](https://ai.pydantic.dev/deferred-tools/) |
-| Use images, audio, video, or documents | [Input](https://ai.pydantic.dev/input/) |
-| Use advanced tool features | [Advanced Tools](https://ai.pydantic.dev/tools-advanced/) |
-| Validate or require approval before tool execution | [Advanced Tools](https://ai.pydantic.dev/tools-advanced/) |
-| Call the model without using an agent | [Direct API](https://ai.pydantic.dev/direct/) |
-| Expose agents as HTTP servers (A2A) | [A2A](https://ai.pydantic.dev/a2a/) |
-| Handle network errors and rate limiting automatically | [Retries](https://ai.pydantic.dev/retries/) |
-| Use LangChain or ACI.dev tools | [Third-Party Tools](https://ai.pydantic.dev/third-party-tools/) |
-| Publish reusable agent extensions as packages | [Extensibility](https://ai.pydantic.dev/extensibility/) |
-| Build custom toolsets, models, or agents | [Extensibility](https://ai.pydantic.dev/extensibility/) |
-| Debug common issues | [Troubleshooting](https://ai.pydantic.dev/troubleshooting/) |
-| Migrate from deprecated APIs | [Changelog](https://ai.pydantic.dev/changelog/) |
-| See advanced real-world examples | [Examples](https://ai.pydantic.dev/examples/) |
-| Look up an import path | [API Reference](https://ai.pydantic.dev/api/) |
+| Create or configure agents | [Create a Basic Agent](#create-a-basic-agent) |
+| Bundle reusable behavior (tools, hooks, instructions) | [Add Capabilities to an Agent](./references/COMMON-TASKS.md#add-capabilities-to-an-agent) |
+| Intercept model requests, tool calls, or runs | [Intercept Agent Lifecycle with Hooks](./references/COMMON-TASKS.md#intercept-agent-lifecycle-with-hooks) |
+| Define agents in YAML/JSON without Python code | [Define Agents Declaratively with Specs](./references/COMMON-TASKS.md#define-agents-declaratively-with-specs) |
+| Use template strings in agent instructions | [Define Agents Declaratively with Specs](./references/COMMON-TASKS.md#define-agents-declaratively-with-specs) |
+| Let my agent call external APIs or functions | [Add Tools to an Agent](#add-tools-to-an-agent) |
+| Organize or restrict which tools an agent can use | [Choosing a Tool Registration Method](./references/ARCHITECTURE.md#choosing-a-tool-registration-method) |
+| Give my agent web search with automatic provider fallback | [Add Capabilities to an Agent](./references/COMMON-TASKS.md#add-capabilities-to-an-agent) |
+| Give my agent URL fetching with automatic provider fallback | [Add Capabilities to an Agent](./references/COMMON-TASKS.md#add-capabilities-to-an-agent) |
+| Give my agent web search or code execution (builtin tools) | [Add Capabilities to an Agent](./references/COMMON-TASKS.md#add-capabilities-to-an-agent) |
+| Search with DuckDuckGo/Tavily/Exa | [Search with DuckDuckGo, Tavily, or Exa](./references/COMMON-TASKS.md#search-with-duckduckgo-tavily-or-exa) |
+| Ensure my agent returns data in a specific format | [Structured Output with Pydantic Models](#structured-output-with-pydantic-models) |
+| Pass database connections, API clients, or config to tools | [Dependency Injection](#dependency-injection) |
+| Access usage stats, message history, or retry count in tools | [Add Tools to an Agent](#add-tools-to-an-agent) |
+| Choose or configure models | [Model Provider Prefixes](./references/ARCHITECTURE.md#model-provider-prefixes) |
+| Automatically switch to backup model when primary fails | [Handle Provider Failures](./references/COMMON-TASKS.md#handle-provider-failures) |
+| Show real-time progress as my agent works | [Show Real-Time Progress](./references/COMMON-TASKS.md#show-real-time-progress) |
+| Work with messages and multimedia | [Work with Message History](./references/COMMON-TASKS.md#work-with-message-history) |
+| Reduce token costs by trimming or filtering conversation history | [Manage Context Size](./references/COMMON-TASKS.md#manage-context-size) |
+| Keep long conversations manageable without losing context | [Manage Context Size](./references/COMMON-TASKS.md#manage-context-size) |
+| Use MCP servers | [Use MCP Servers](./references/COMMON-TASKS.md#use-mcp-servers) |
+| Build multi-step graphs | [Build Multi-Step Workflows with Graphs](./references/COMMON-TASKS.md#build-multi-step-workflows-with-graphs) |
+| Debug a failed agent run or see what went wrong | [Debug a Failed Agent Run](./references/COMMON-TASKS.md#debug-a-failed-agent-run) |
+| Make my agent resilient to temporary failures | [Make an Agent Resilient with Retries](./references/COMMON-TASKS.md#make-an-agent-resilient-with-retries) |
+| Understand why my agent made specific decisions | [Debug and Validate Agent Behavior](./references/COMMON-TASKS.md#debug-and-validate-agent-behavior) |
+| Write deterministic tests for my agent | [Test Agent Behavior](./references/COMMON-TASKS.md#test-agent-behavior) |
+| Enable thinking/reasoning across any provider | [Enable Thinking Across Providers](./references/COMMON-TASKS.md#enable-thinking-across-providers) |
+| Systematically verify my agent works correctly | [Evaluations (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
+| Use embeddings for RAG | [Embeddings (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
+| Use durable execution | [Durable Execution (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
+| Have one agent delegate tasks to another | [Coordinate Multiple Agents](./references/COMMON-TASKS.md#coordinate-multiple-agents) |
+| Route requests to different agents based on intent | [Coordinate Multiple Agents](./references/COMMON-TASKS.md#coordinate-multiple-agents) |
+| Require tool approval (human-in-the-loop) | [Require Tool Approval (Human in the Loop)](./references/COMMON-TASKS.md#require-tool-approval-human-in-the-loop) |
+| Use images, audio, video, or documents | [Send Images, Audio, Video, or Documents to the Model](./references/COMMON-TASKS.md#send-images-audio-video-or-documents-to-the-model) |
+| Use advanced tool features | [Require Tool Approval (Human in the Loop)](./references/COMMON-TASKS.md#require-tool-approval-human-in-the-loop) |
+| Validate or require approval before tool execution | [Require Tool Approval (Human in the Loop)](./references/COMMON-TASKS.md#require-tool-approval-human-in-the-loop) |
+| Call the model without using an agent | [Direct API (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
+| Expose agents as HTTP servers (A2A) | [A2A (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
+| Handle network errors and rate limiting automatically | [Make an Agent Resilient with Retries](./references/COMMON-TASKS.md#make-an-agent-resilient-with-retries) |
+| Use LangChain or ACI.dev tools | [Third-Party Tools (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
+| Publish reusable agent extensions as packages | [Custom Toolsets/Models/Capabilities (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
+| Build custom toolsets, models, or agents | [Custom Toolsets/Models/Capabilities (in Advanced Features)](./references/COMMON-TASKS.md#advanced-and-less-common-features) |
+| Debug common issues | [Debug a Failed Agent Run](./references/COMMON-TASKS.md#debug-a-failed-agent-run) |
+| Migrate from deprecated APIs | [Working with the Installed Pydantic AI Package](./references/COMMON-TASKS.md#working-with-the-installed-pydantic-ai-package) |
+| See advanced real-world examples | [Working with the Installed Pydantic AI Package](./references/COMMON-TASKS.md#working-with-the-installed-pydantic-ai-package) |
+| Look up an import path | [Working with the Installed Pydantic AI Package](./references/COMMON-TASKS.md#working-with-the-installed-pydantic-ai-package) |
 
 ## Architecture and Decisions
 
@@ -278,7 +278,7 @@ Load [Architecture and Decision Guide](./references/ARCHITECTURE.md) for detaile
 ## Key Practices
 
 - **Python 3.10+** compatibility required
-- **Observability**: Pydantic AI has first-class integration with [Logfire](https://logfire.pydantic.dev/) for tracing agent runs, tool calls, and model requests. Add it with `logfire.instrument_pydantic_ai()`. For deeper HTTP-level visibility, `logfire.instrument_httpx(capture_all=True)` captures the exact payloads sent to model providers.
+- **Observability**: Pydantic AI has first-class integration with Logfire for tracing agent runs, tool calls, and model requests. Add it with `logfire.instrument_pydantic_ai()`. For deeper HTTP-level visibility, `logfire.instrument_httpx(capture_all=True)` captures the exact payloads sent to model providers.
 - **Testing**: Use `TestModel` for deterministic tests, `FunctionModel` for custom logic
 
 ## Common Gotchas

--- a/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
+++ b/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
@@ -1,0 +1,158 @@
+# Agents Core
+
+Read this file when the user needs the core `Agent` workflow: creating agents, choosing output types, using dependencies, defining specs, selecting models, or choosing how to run/stream an agent.
+
+## Create a Basic Agent
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    instructions='Be concise, reply with one sentence.',
+)
+
+result = agent.run_sync('Where does "hello world" come from?')
+print(result.output)
+```
+
+## Structured Output with Pydantic Models
+
+Use `output_type=MyModel` when the model should return validated structured data.
+
+```python
+from pydantic import BaseModel
+
+from pydantic_ai import Agent
+
+
+class CityLocation(BaseModel):
+    city: str
+    country: str
+
+
+agent = Agent('google-gla:gemini-3-flash-preview', output_type=CityLocation)
+result = agent.run_sync('Where were the olympics held in 2012?')
+print(result.output)
+```
+
+If the user is choosing between output modes:
+
+- `output_type=str` for plain text
+- `output_type=MyModel` for structured output
+- `TextOutput` for custom text parsing
+- `NativeOutput` or `ToolOutput` when they need explicit output-mode control
+
+## Dependency Injection
+
+Use `deps_type=...` plus `RunContext[...]` when tools or instructions need app state.
+
+```python
+from pydantic_ai import Agent, RunContext
+
+agent = Agent('openai:gpt-5.2', deps_type=str)
+
+
+@agent.instructions
+def add_user_name(ctx: RunContext[str]) -> str:
+    return f"The user's name is {ctx.deps}."
+```
+
+Use `@agent.tool` when the tool needs `RunContext`. Use `@agent.tool_plain` when it does not.
+
+## Define Agents Declaratively with Specs
+
+Use YAML or JSON specs when configuration should live outside Python code.
+
+```yaml
+model: anthropic:claude-opus-4-6
+instructions: "You are helping {{user_name}} with research."
+capabilities:
+  - WebSearch
+  - Thinking:
+      effort: high
+```
+
+```python
+from dataclasses import dataclass
+
+from pydantic_ai import Agent
+
+
+@dataclass
+class UserContext:
+    user_name: str
+
+
+agent = Agent.from_file('agent.yaml', deps_type=UserContext)
+result = agent.run_sync('Find recent papers on AI safety', deps=UserContext(user_name='Alice'))
+```
+
+Template strings are part of the spec flow, so route template-string questions here too.
+
+## Choose or Configure Models
+
+Model strings use the `"provider:model-name"` format.
+
+Examples:
+
+- `openai:gpt-5.2`
+- `anthropic:claude-sonnet-4-6`
+- `google-gla:gemini-3-pro-preview`
+
+Use a model instance instead of a string when the user needs provider-specific constructor arguments.
+
+## Run Methods and Streaming
+
+Pick a run method based on the interaction pattern:
+
+- `run()` for async runs that complete normally
+- `run_sync()` for synchronous scripts and notebooks
+- `run_stream()` for streaming final output
+- `run_stream_sync()` for sync streaming
+- `run_stream_events()` when the caller needs the typed event stream directly
+- `iter()` when the caller needs step-by-step control over the agent loop
+
+Use `event_stream_handler=` with `run()` or `run_stream()` when the user wants progress updates without manually consuming the event stream:
+
+```python
+from collections.abc import AsyncIterable
+
+from pydantic_ai import Agent, AgentStreamEvent, FunctionToolCallEvent, RunContext
+
+agent = Agent('openai:gpt-5.2')
+
+
+async def stream_handler(ctx: RunContext[None], events: AsyncIterable[AgentStreamEvent]):
+    async for event in events:
+        if isinstance(event, FunctionToolCallEvent):
+            print(f'Calling {event.part.tool_name}...')
+
+
+async def main():
+    await agent.run('Do the task', event_stream_handler=stream_handler)
+```
+
+## Handle Provider Failures
+
+Use `FallbackModel` when the user wants automatic provider or model failover.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.models.fallback import FallbackModel
+from pydantic_ai.models.openai import OpenAIChatModel
+
+fallback = FallbackModel(
+    OpenAIChatModel('gpt-5.2'),
+    AnthropicModel('claude-sonnet-4-6'),
+)
+
+agent = Agent(fallback)
+```
+
+Good defaults:
+
+- primary expensive/strong model, cheaper fallback for resilience
+- same prompt/output contract across both models
+- per-model settings only when the user actually needs them

--- a/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
+++ b/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
@@ -4,6 +4,7 @@ Detailed decision trees, comparison tables, and architecture overview for Pydant
 
 ## Contents
 
+- [Task-Family References](#task-family-references)
 - [Decision Trees](#decision-trees)
   - [Choosing a Tool Registration Method](#choosing-a-tool-registration-method)
   - [Choosing an Output Mode](#choosing-an-output-mode)
@@ -18,6 +19,21 @@ Detailed decision trees, comparison tables, and architecture overview for Pydant
   - [Built-in Capabilities](#built-in-capabilities)
   - [When to Use Each Agent Method](#when-to-use-each-agent-method)
 - [Architecture Overview](#architecture-overview)
+
+## Task-Family References
+
+Use this file for comparisons and abstraction choices.
+
+If the user already knows what they want to do, load the narrower task guide instead:
+
+- [AGENTS-CORE.md](./AGENTS-CORE.md)
+- [CAPABILITIES-AND-HOOKS.md](./CAPABILITIES-AND-HOOKS.md)
+- [TOOLS-CORE.md](./TOOLS-CORE.md)
+- [BUILTIN-TOOLS.md](./BUILTIN-TOOLS.md)
+- [TOOLS-ADVANCED.md](./TOOLS-ADVANCED.md)
+- [INPUT-AND-HISTORY.md](./INPUT-AND-HISTORY.md)
+- [TESTING-AND-DEBUGGING.md](./TESTING-AND-DEBUGGING.md)
+- [ORCHESTRATION-AND-INTEGRATIONS.md](./ORCHESTRATION-AND-INTEGRATIONS.md)
 
 ## Decision Trees
 
@@ -182,7 +198,7 @@ Need deterministic, fast tests?
 | Receiving an async iterable of typed events (tool calls, results, final output) | `agent.run_stream_events()` |
 | Inspecting or modifying state between agent steps, human-in-the-loop approval | `agent.iter()` |
 
-See [Show Real-Time Progress](./COMMON-TASKS.md#show-real-time-progress) for `event_stream_handler` details.
+See [Run Methods and Streaming](./AGENTS-CORE.md#run-methods-and-streaming) for `event_stream_handler` details.
 
 ## Architecture Overview
 

--- a/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
+++ b/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
@@ -2,6 +2,23 @@
 
 Detailed decision trees, comparison tables, and architecture overview for Pydantic AI.
 
+## Contents
+
+- [Decision Trees](#decision-trees)
+  - [Choosing a Tool Registration Method](#choosing-a-tool-registration-method)
+  - [Choosing an Output Mode](#choosing-an-output-mode)
+  - [Choosing a Multi-Agent Pattern](#choosing-a-multi-agent-pattern)
+  - [Choosing How to Extend Agent Behavior](#choosing-how-to-extend-agent-behavior)
+  - [Choosing a Capability](#choosing-a-capability)
+  - [Choosing a Testing Approach](#choosing-a-testing-approach)
+- [Comparison Tables](#comparison-tables)
+  - [Output Mode Comparison](#output-mode-comparison)
+  - [Model Provider Prefixes](#model-provider-prefixes)
+  - [Tool Decorator Comparison](#tool-decorator-comparison)
+  - [Built-in Capabilities](#built-in-capabilities)
+  - [When to Use Each Agent Method](#when-to-use-each-agent-method)
+- [Architecture Overview](#architecture-overview)
+
 ## Decision Trees
 
 ### Choosing a Tool Registration Method
@@ -127,7 +144,7 @@ Need deterministic, fast tests?
 | Cerebras | `cerebras:` | `cerebras:llama-4-scout-17b-16e-instruct` |
 | Heroku | `heroku:` | `heroku:claude-sonnet-4-6` |
 
-**Additional prefixes:** `litellm:`, `nebius:`, `ovhcloud:`, `alibaba:`, `sambanova:`, `vercel:`, `outlines:`, `moonshotai:`. For truly custom providers, subclass `Model` or use `OpenAIChatModel` with a custom `base_url`. See [Models](https://ai.pydantic.dev/models/).
+**Additional prefixes:** `litellm:`, `nebius:`, `ovhcloud:`, `alibaba:`, `sambanova:`, `vercel:`, `outlines:`, `moonshotai:`. For truly custom providers, subclass `Model` or use `OpenAIChatModel` with a custom `base_url`.
 
 ### Tool Decorator Comparison
 
@@ -165,7 +182,7 @@ Need deterministic, fast tests?
 | Receiving an async iterable of typed events (tool calls, results, final output) | `agent.run_stream_events()` |
 | Inspecting or modifying state between agent steps, human-in-the-loop approval | `agent.iter()` |
 
-See [Streaming All Events](https://ai.pydantic.dev/agents/#streaming-all-events) for `event_stream_handler` details.
+See [Show Real-Time Progress](./COMMON-TASKS.md#show-real-time-progress) for `event_stream_handler` details.
 
 ## Architecture Overview
 

--- a/skills/building-pydantic-ai-agents/references/BUILTIN-TOOLS.md
+++ b/skills/building-pydantic-ai-agents/references/BUILTIN-TOOLS.md
@@ -1,0 +1,66 @@
+# Built-in Tools
+
+Read this file when the user wants provider-native tools such as web search, web fetch, code execution, memory, or file search.
+
+Prefer capabilities like `WebSearch()` or `WebFetch()` when the user wants a provider-agnostic solution. Use built-in tools directly when they explicitly want provider-native behavior or provider-specific configuration.
+
+## Give My Agent Web Search or Code Execution
+
+Builtin tools are passed via `builtin_tools=[...]`.
+
+```python
+from pydantic_ai import Agent, WebSearchTool
+
+agent = Agent('openai-responses:gpt-5.2', builtin_tools=[WebSearchTool()])
+result = agent.run_sync('Give me a sentence with the biggest news in AI this week.')
+print(result.output)
+```
+
+For OpenAI web search, use the Responses API model prefix (`openai-responses:`), not `openai:`.
+
+## Built-in Tool Defaults
+
+Reach for these when the provider supports them:
+
+- `WebSearchTool`
+- `WebFetchTool`
+- `CodeExecutionTool`
+- `ImageGenerationTool`
+- `MemoryTool`
+- `MCPServerTool`
+- `FileSearchTool`
+
+## Dynamic Built-in Tool Configuration
+
+Prepare built-in tools from `RunContext` when configuration depends on the current user or request.
+
+```python
+from pydantic_ai import Agent, RunContext, WebSearchTool
+
+
+async def prepared_web_search(ctx: RunContext[dict]) -> WebSearchTool | None:
+    if not ctx.deps.get('location'):
+        return None
+    return WebSearchTool(user_location={'city': ctx.deps['location']})
+
+
+agent = Agent(
+    'openai-responses:gpt-5.2',
+    builtin_tools=[prepared_web_search],
+    deps_type=dict,
+)
+```
+
+## When to Use Built-in Tools vs Capabilities
+
+Use built-in tools when:
+
+- the user explicitly wants provider-native behavior
+- the provider-specific configuration matters
+- the user already picked a provider that supports the tool
+
+Use capabilities when:
+
+- the code should work across providers
+- you want local fallback when builtin support is missing
+- the user has not committed to a provider yet

--- a/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
+++ b/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
@@ -1,0 +1,102 @@
+# Capabilities and Hooks
+
+Read this file when the user wants reusable agent behavior, provider-adaptive tools, or lifecycle interception.
+
+## Add Capabilities to an Agent
+
+Capabilities bundle reusable behavior and compose automatically.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import Thinking, WebSearch
+
+agent = Agent(
+    'anthropic:claude-opus-4-6',
+    capabilities=[
+        Thinking(effort='high'),
+        WebSearch(),
+    ],
+)
+```
+
+Provider-adaptive capabilities to reach for first:
+
+- `Thinking`
+- `WebSearch`
+- `WebFetch`
+- `ImageGeneration`
+- `MCP`
+
+Use capabilities when the user wants behavior that should survive model/provider changes.
+
+## Enable Thinking Across Providers
+
+Use the unified `Thinking` capability or the `thinking` model setting.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import Thinking
+
+agent = Agent('anthropic:claude-opus-4-6', capabilities=[Thinking(effort='high')])
+agent = Agent('anthropic:claude-opus-4-6', model_settings={'thinking': 'high'})
+```
+
+Supported effort values:
+
+- `True`
+- `False`
+- `'minimal'`
+- `'low'`
+- `'medium'`
+- `'high'`
+- `'xhigh'`
+
+## Intercept Agent Lifecycle with Hooks
+
+Use `Hooks` for decorator-based lifecycle interception.
+
+```python
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.capabilities.hooks import Hooks
+from pydantic_ai.models import ModelRequestContext
+
+hooks = Hooks()
+
+
+@hooks.on.before_model_request
+async def log_request(ctx: RunContext[None], request_context: ModelRequestContext) -> ModelRequestContext:
+    print(f'Sending {len(request_context.messages)} messages')
+    return request_context
+
+
+@hooks.on.before_tool_execute(tools=['send_email'])
+async def audit_tool(ctx, *, call, tool_def, args):
+    print(f'Executing {call.tool_name}')
+    return args
+
+
+agent = Agent('openai:gpt-5.2', capabilities=[hooks])
+```
+
+Important hook families:
+
+- run-level hooks
+- node-level hooks
+- model-request hooks
+- tool-validation hooks
+- tool-execution hooks
+- event-stream hooks
+
+Use hooks when the user wants observability, auditing, or light interception without adding a new abstraction.
+
+## Build a Custom Capability
+
+Subclass `AbstractCapability` when the user wants reusable behavior that combines tools, hooks, instructions, or model settings into one package.
+
+Reach for a custom capability when:
+
+- the same bundle should be reused across multiple agents
+- `Hooks` alone is not enough
+- the behavior should be installable or declarative
+
+Keep custom capabilities focused. If the user only needs one tool or one hook, do not introduce a capability.

--- a/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
+++ b/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
@@ -2,6 +2,29 @@
 
 Detailed implementation guidance with code examples for common Pydantic AI tasks.
 
+## Contents
+
+- [Add Capabilities to an Agent](#add-capabilities-to-an-agent)
+- [Intercept Agent Lifecycle with Hooks](#intercept-agent-lifecycle-with-hooks)
+- [Define Agents Declaratively with Specs](#define-agents-declaratively-with-specs)
+- [Enable Thinking Across Providers](#enable-thinking-across-providers)
+- [Use MCP Servers](#use-mcp-servers)
+- [Search with DuckDuckGo, Tavily, or Exa](#search-with-duckduckgo-tavily-or-exa)
+- [Require Tool Approval (Human in the Loop)](#require-tool-approval-human-in-the-loop)
+- [Send Images, Audio, Video, or Documents to the Model](#send-images-audio-video-or-documents-to-the-model)
+- [Manage Context Size](#manage-context-size)
+- [Work with Message History](#work-with-message-history)
+- [Show Real-Time Progress](#show-real-time-progress)
+- [Handle Provider Failures](#handle-provider-failures)
+- [Make an Agent Resilient with Retries](#make-an-agent-resilient-with-retries)
+- [Debug a Failed Agent Run](#debug-a-failed-agent-run)
+- [Test Agent Behavior](#test-agent-behavior)
+- [Coordinate Multiple Agents](#coordinate-multiple-agents)
+- [Build Multi-Step Workflows with Graphs](#build-multi-step-workflows-with-graphs)
+- [Debug and Validate Agent Behavior](#debug-and-validate-agent-behavior)
+- [Advanced and Less Common Features](#advanced-and-less-common-features)
+- [Working with the Installed Pydantic AI Package](#working-with-the-installed-pydantic-ai-package)
+
 ## Add Capabilities to an Agent
 
 Use capabilities to bundle reusable behavior. Multiple capabilities compose automatically.
@@ -21,8 +44,6 @@ agent = Agent(
 ```
 
 **WebSearch** auto-detects whether the model supports builtin web search. If so, it uses the native tool; otherwise, it falls back to a local implementation (e.g., DuckDuckGo). Same pattern applies to `WebFetch`, `ImageGeneration`, and `MCP`.
-
-**Docs:** [Capabilities](https://ai.pydantic.dev/capabilities/) · [Built-in Capabilities](https://ai.pydantic.dev/capabilities/#built-in-capabilities)
 
 ---
 
@@ -54,8 +75,6 @@ agent = Agent('openai:gpt-5.2', capabilities=[hooks])
 ```
 
 **Hook types:** `before_run`/`after_run`, `run` (wrap), `run_error`, `before_node_run`/`after_node_run`, `node_run` (wrap), `node_run_error`, `before_model_request`/`after_model_request`, `model_request` (wrap), `model_request_error`, `before_tool_validate`/`after_tool_validate`, `tool_validate` (wrap), `tool_validate_error`, `before_tool_execute`/`after_tool_execute`, `tool_execute` (wrap), `tool_execute_error`, `prepare_tools`, `run_event_stream`, `event`.
-
-**Docs:** [Hooks](https://ai.pydantic.dev/hooks/) · [Hooking into the Lifecycle](https://ai.pydantic.dev/capabilities/#hooking-into-the-lifecycle)
 
 ---
 
@@ -92,8 +111,6 @@ result = agent.run_sync('Find recent papers on AI safety', deps=UserContext(user
 
 **Capability spec syntax:** `'WebSearch'` (no args), `{'Thinking': {'effort': 'high'}}` (kwargs), `{'Thinking': 'high'}` (single arg).
 
-**Docs:** [Agent Specs](https://ai.pydantic.dev/agent-spec/) · [Template Strings](https://ai.pydantic.dev/agent-spec/#template-strings)
-
 ---
 
 ## Enable Thinking Across Providers
@@ -113,7 +130,104 @@ agent = Agent('anthropic:claude-opus-4-6', model_settings={'thinking': 'high'})
 
 **Effort levels:** `True` (default effort), `False` (disable), `'minimal'`, `'low'`, `'medium'`, `'high'`, `'xhigh'`. Automatically mapped to each provider's native format (Anthropic adaptive thinking, OpenAI reasoning_effort, Google thinking_level, etc.).
 
-**Docs:** [Thinking](https://ai.pydantic.dev/thinking/) · [Unified Thinking Settings](https://ai.pydantic.dev/thinking/#unified-thinking-settings)
+---
+
+## Use MCP Servers
+
+Attach an MCP server as a toolset on the Agent. Use `MCPServerStdio` for subprocess-based servers or `MCPServerStreamableHTTP` for HTTP-based ones.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPServerStdio
+
+server = MCPServerStdio('python', args=['mcp_server.py'], timeout=10)
+agent = Agent('openai:gpt-5.2', toolsets=[server])
+
+async def main():
+    result = await agent.run('What is the weather in Paris?')
+    print(result.output)
+```
+
+**Gotcha:** Use `async with agent` (or `async with server`) for explicit lifecycle control. `MCPServerSSE` exists but is deprecated — prefer `MCPServerStreamableHTTP`.
+
+---
+
+## Search with DuckDuckGo, Tavily, or Exa
+
+Use `pydantic_ai.common_tools` for search-engine tools. DuckDuckGo is free; Tavily and Exa require API keys. Distinct from the `WebSearch` capability — these are explicit tool functions.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.common_tools.duckduckgo import duckduckgo_search_tool
+
+agent = Agent(
+    'openai:gpt-5.2',
+    tools=[duckduckgo_search_tool()],
+    instructions='Search DuckDuckGo for the given query and return the results.',
+)
+
+result = agent.run_sync(
+    'Can you list the top five highest-grossing animated films of 2025?'
+)
+print(result.output)
+```
+
+**Install:** `uv add 'pydantic-ai-slim[duckduckgo]'` (or `[tavily]`/`[exa]`). For Tavily/Exa swap the import for `tavily_search_tool` / `ExaToolset`.
+
+---
+
+## Require Tool Approval (Human in the Loop)
+
+Use deferred tools to pause execution until external approval is granted. Mark a tool with `requires_approval=True`, then resume the run by passing `DeferredToolResults` back.
+
+```python
+from pydantic_ai import (
+    Agent,
+    DeferredToolRequests,
+    DeferredToolResults,
+    ToolDenied,
+)
+
+agent = Agent('openai:gpt-5.2', output_type=[str, DeferredToolRequests])
+
+@agent.tool_plain(requires_approval=True)
+def delete_file(path: str) -> str:
+    return f'File {path!r} deleted'
+
+result = agent.run_sync('Delete __init__.py')
+messages = result.all_messages()
+
+assert isinstance(result.output, DeferredToolRequests)
+results = DeferredToolResults()
+for call in result.output.approvals:
+    results.approvals[call.tool_call_id] = ToolDenied('Deleting files is not allowed')
+
+result = agent.run_sync('Continue', message_history=messages, deferred_tool_results=results)
+print(result.output)
+```
+
+**Gotcha:** `output_type` MUST include `DeferredToolRequests`. For conditional approval (only some calls need it), `raise ApprovalRequired(...)` from inside the tool instead of using `requires_approval=True`.
+
+---
+
+## Send Images, Audio, Video, or Documents to the Model
+
+Pass multimodal content as a list mixing text with `ImageUrl`/`AudioUrl`/`VideoUrl`/`DocumentUrl` (URL-based) or `BinaryContent` (in-memory).
+
+```python
+from pydantic_ai import Agent, ImageUrl
+
+agent = Agent(model='openai:gpt-5.2')
+result = agent.run_sync(
+    [
+        'What company is this logo from?',
+        ImageUrl(url='https://iili.io/3Hs4FMg.png'),
+    ]
+)
+print(result.output)
+```
+
+**Gotcha:** Not all models support all input types — check provider documentation. `BinaryContent(data=..., media_type='image/png')` is the alternative for in-memory assets.
 
 ---
 
@@ -134,7 +248,25 @@ agent = Agent('openai:gpt-5.2', history_processors=[keep_recent])
 
 **Also use for:** Privacy filtering (remove PII), summarizing old messages, role-based access.
 
-**Docs:** [Processing Message History](https://ai.pydantic.dev/message-history/#processing-message-history) · [Summarize Old Messages](https://ai.pydantic.dev/message-history/#summarize-old-messages)
+---
+
+## Work with Message History
+
+Pass `result.new_messages()` from one run as `message_history=` to the next to continue a conversation across runs.
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2', instructions='Be a helpful assistant.')
+
+result1 = agent.run_sync('Tell me a joke.')
+print(result1.output)
+
+result2 = agent.run_sync('Explain?', message_history=result1.new_messages())
+print(result2.output)
+```
+
+**Gotcha:** `new_messages()` returns only the current run; `all_messages()` returns the full history. When `message_history=` is passed, no new system prompt is generated — the existing history is assumed to include one.
 
 ---
 
@@ -162,8 +294,6 @@ async def main():
 
 **Also use for:** Logging, analytics, debugging, progress bars in UIs.
 
-**Docs:** [Streaming Events and Final Output](https://ai.pydantic.dev/agents/#streaming-events-and-final-output) · [Streaming All Events](https://ai.pydantic.dev/agents/#streaming-all-events)
-
 ---
 
 ## Handle Provider Failures
@@ -185,7 +315,44 @@ agent = Agent(fallback)
 
 **Also use for:** Cost optimization (expensive → cheap), rate limit handling, regional failover.
 
-**Docs:** [Fallback Model](https://ai.pydantic.dev/models/#fallback-model) · [Per-Model Settings](https://ai.pydantic.dev/models/#per-model-settings)
+---
+
+## Make an Agent Resilient with Retries
+
+Raise `ModelRetry` from inside a tool to ask the model to call it again with corrected arguments. Set per-tool `retries=N` to override the Agent default.
+
+```python
+from pydantic_ai import Agent, RunContext, ModelRetry
+
+@agent.tool(retries=2)
+def get_user_by_name(ctx: RunContext[DatabaseConn], name: str) -> int:
+    user_id = ctx.deps.users.get(name=name)
+    if user_id is None:
+        raise ModelRetry(
+            f'No user found with name {name!r}, remember to provide their full name'
+        )
+    return user_id
+```
+
+**Gotcha:** Default is 1 retry. When the limit is exceeded and `ModelRetry` keeps firing, the agent raises `UnexpectedModelBehavior`. Current attempt is on `ctx.retry`.
+
+---
+
+## Debug a Failed Agent Run
+
+Wrap a run in `capture_run_messages()` and catch `UnexpectedModelBehavior` to inspect the full request/response history at the point of failure.
+
+```python
+from pydantic_ai import Agent, ModelRetry, UnexpectedModelBehavior, capture_run_messages
+
+with capture_run_messages() as messages:
+    try:
+        result = agent.run_sync('Please get me the volume of a box with size 6.')
+    except UnexpectedModelBehavior as e:
+        print('messages:', messages)
+```
+
+**Gotcha:** Captured messages include retries and tool-call attempts. Distinct from Logfire — use Logfire for production tracing, this for in-process debugging.
 
 ---
 
@@ -223,8 +390,6 @@ with agent.override(model=FunctionModel(custom_model)):
 
 **Also use for:** Capturing requests for assertions, simulating errors, testing retries.
 
-**Docs:** [Unit testing with TestModel](https://ai.pydantic.dev/testing/#unit-testing-with-testmodel) · [Unit testing with FunctionModel](https://ai.pydantic.dev/testing/#unit-testing-with-functionmodel)
-
 ---
 
 ## Coordinate Multiple Agents
@@ -246,13 +411,43 @@ async def research(ctx: RunContext, topic: str) -> str:
 
 **Also use for:** Triage/routing, specialist hand-off, graph-based workflows.
 
-**Docs:** [Agent Delegation](https://ai.pydantic.dev/multi-agent-applications/#agent-delegation) · [Programmatic Agent Hand-off](https://ai.pydantic.dev/multi-agent-applications/#programmatic-agent-hand-off)
+---
+
+## Build Multi-Step Workflows with Graphs
+
+Use `pydantic_graph` (separate package, ships in the same monorepo) to define typed nodes and run them as a state machine. Outgoing edges are determined by `run()` return type annotations.
+
+```python
+from dataclasses import dataclass
+from pydantic_graph import BaseNode, End, Graph, GraphRunContext
+
+@dataclass
+class FirstNode(BaseNode[None, None, int]):
+    value: int
+
+    async def run(self, ctx: GraphRunContext) -> 'SecondNode | End[int]':
+        if self.value >= 5:
+            return End(self.value)
+        return SecondNode(self.value + 1)
+
+@dataclass
+class SecondNode(BaseNode):
+    value: int
+
+    async def run(self, ctx: GraphRunContext) -> FirstNode:
+        return FirstNode(self.value)
+
+graph = Graph(nodes=[FirstNode, SecondNode])
+result = graph.run_sync(FirstNode(0))
+```
+
+**Gotcha:** `End[T]` terminates the graph with output of type `T`.
 
 ---
 
 ## Debug and Validate Agent Behavior
 
-Instrument with [Logfire](https://logfire.pydantic.dev/) to see exact model requests, tool calls, and validate LLM outputs. Each agent run becomes a parent trace with child spans for every tool call and LLM request.
+Instrument with Logfire to see exact model requests, tool calls, and validate LLM outputs. Each agent run becomes a parent trace with child spans for every tool call and LLM request.
 
 ```python
 import logfire
@@ -271,4 +466,28 @@ logfire.instrument_httpx(capture_all=True)
 
 **Use for:** Debugging unexpected behavior, validating tool schemas, understanding what's sent to providers, production monitoring.
 
-**Docs:** [Using Logfire](https://ai.pydantic.dev/logfire/#using-logfire) · [Monitoring HTTP Requests](https://ai.pydantic.dev/logfire/#monitoring-http-requests)
+---
+
+## Advanced and Less Common Features
+
+For features below, the offline reference is the relevant module in the locally-installed `pydantic_ai` package. Run `python -c "import pydantic_ai; print(pydantic_ai.__file__)"` to find the source root, then browse the listed module.
+
+- **Embeddings for RAG** — `from pydantic_ai import Embedder` — `Embedder('openai:text-embedding-3-small')` exposes `embed_query()` for search queries and `embed_documents()` for content indexing.
+- **Direct API** — `from pydantic_ai.direct import model_request_sync, model_request` — call a model without constructing an `Agent`. Sync or async.
+- **A2A HTTP servers** — `agent.to_a2a()` returns an ASGI app implementing the A2A protocol. Run with uvicorn or any ASGI server.
+- **Durable Execution (Temporal)** — `from pydantic_ai.durable_exec.temporal import TemporalAgent, PydanticAIWorkflow, PydanticAIPlugin` — wrap an agent with `TemporalAgent()` to preserve progress across transient failures. DBOS and Prefect have parallel modules.
+- **LangChain tools** — `from pydantic_ai.ext.langchain import tool_from_langchain, LangChainToolset` — adapt individual tools or entire toolsets.
+- **ACI.dev tools** — `from pydantic_ai.ext.aci import tool_from_aci, ACIToolset`
+- **Custom toolsets / models / capabilities** — base classes: `AbstractToolset`/`WrapperToolset` from `pydantic_ai.toolsets`; `Model`/`WrapperModel` from `pydantic_ai.models`; `AbstractAgent`/`WrapperAgent` from `pydantic_ai.agent`; `AbstractCapability` from `pydantic_ai.capabilities`.
+- **Evaluations (`pydantic_evals`)** — `from pydantic_evals import Case, Dataset` and `from pydantic_evals.evaluators import IsInstance, Evaluator, EvaluatorContext` — separate package, install with `pip install pydantic-evals`.
+
+---
+
+## Working with the Installed Pydantic AI Package
+
+Useful when the offline reference doesn't cover a specific symbol or you want to read source for an advanced feature.
+
+- **Find the source root:** `python -c "import pydantic_ai; print(pydantic_ai.__file__)"` — browse the package directory for type stubs, docstrings, and submodule layout.
+- **Browse real-world examples:** `pip install pydantic-ai-examples`, then `python -c "import pydantic_ai_examples; print(pydantic_ai_examples.__file__)"`.
+- **Read the changelog:** the source tree contains `docs/changelog.md`. On PyPI, version history is on the project page.
+- **Install variants:** `pip install pydantic-ai` (full) or `pip install pydantic-ai-slim` with provider/feature extras like `[openai,duckduckgo,tavily]`.

--- a/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
+++ b/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
@@ -1,493 +1,108 @@
-# Common Tasks
+# Task Reference Map
 
-Detailed implementation guidance with code examples for common Pydantic AI tasks.
+This file exists as a compatibility index for older links into `COMMON-TASKS.md`.
 
-## Contents
+Prefer the narrower task-family guides below so the agent loads only the material it needs:
 
-- [Add Capabilities to an Agent](#add-capabilities-to-an-agent)
-- [Intercept Agent Lifecycle with Hooks](#intercept-agent-lifecycle-with-hooks)
-- [Define Agents Declaratively with Specs](#define-agents-declaratively-with-specs)
-- [Enable Thinking Across Providers](#enable-thinking-across-providers)
-- [Use MCP Servers](#use-mcp-servers)
-- [Search with DuckDuckGo, Tavily, or Exa](#search-with-duckduckgo-tavily-or-exa)
-- [Require Tool Approval (Human in the Loop)](#require-tool-approval-human-in-the-loop)
-- [Send Images, Audio, Video, or Documents to the Model](#send-images-audio-video-or-documents-to-the-model)
-- [Manage Context Size](#manage-context-size)
-- [Work with Message History](#work-with-message-history)
-- [Show Real-Time Progress](#show-real-time-progress)
-- [Handle Provider Failures](#handle-provider-failures)
-- [Make an Agent Resilient with Retries](#make-an-agent-resilient-with-retries)
-- [Debug a Failed Agent Run](#debug-a-failed-agent-run)
-- [Test Agent Behavior](#test-agent-behavior)
-- [Coordinate Multiple Agents](#coordinate-multiple-agents)
-- [Build Multi-Step Workflows with Graphs](#build-multi-step-workflows-with-graphs)
-- [Debug and Validate Agent Behavior](#debug-and-validate-agent-behavior)
-- [Advanced and Less Common Features](#advanced-and-less-common-features)
-- [Working with the Installed Pydantic AI Package](#working-with-the-installed-pydantic-ai-package)
+- [AGENTS-CORE.md](./AGENTS-CORE.md) — agent creation, output, deps, specs, models, run methods
+- [CAPABILITIES-AND-HOOKS.md](./CAPABILITIES-AND-HOOKS.md) — `Thinking`, `WebSearch`, `Hooks`, custom capabilities
+- [TOOLS-CORE.md](./TOOLS-CORE.md) — `@agent.tool`, `Tool`, toolsets, MCP, common search tools
+- [BUILTIN-TOOLS.md](./BUILTIN-TOOLS.md) — provider-native tools like `WebSearchTool` and `CodeExecutionTool`
+- [TOOLS-ADVANCED.md](./TOOLS-ADVANCED.md) — approval, retries, `ToolReturn`, timeouts, validators, deferred loading
+- [INPUT-AND-HISTORY.md](./INPUT-AND-HISTORY.md) — multimodal input, message history, history processors
+- [TESTING-AND-DEBUGGING.md](./TESTING-AND-DEBUGGING.md) — `TestModel`, `FunctionModel`, `capture_run_messages`, Logfire
+- [ORCHESTRATION-AND-INTEGRATIONS.md](./ORCHESTRATION-AND-INTEGRATIONS.md) — multi-agent patterns, graphs, A2A, direct API, durable execution, embeddings, evals, third-party tools
 
 ## Add Capabilities to an Agent
 
-Use capabilities to bundle reusable behavior. Multiple capabilities compose automatically.
-
-```python
-from pydantic_ai import Agent
-from pydantic_ai.capabilities import Thinking, WebSearch
-
-# Built-in capabilities: just pass instances
-agent = Agent(
-    'anthropic:claude-opus-4-6',
-    capabilities=[
-        Thinking(effort='high'),
-        WebSearch(),
-    ],
-)
-```
-
-**WebSearch** auto-detects whether the model supports builtin web search. If so, it uses the native tool; otherwise, it falls back to a local implementation (e.g., DuckDuckGo). Same pattern applies to `WebFetch`, `ImageGeneration`, and `MCP`.
-
----
+Read [Add Capabilities](./CAPABILITIES-AND-HOOKS.md#add-capabilities-to-an-agent).
 
 ## Intercept Agent Lifecycle with Hooks
 
-Use `Hooks` for lightweight lifecycle interception via decorators. For reusable behavior that combines hooks with tools/instructions, subclass `AbstractCapability` instead.
-
-```python
-from pydantic_ai import Agent, RunContext
-from pydantic_ai.capabilities.hooks import Hooks
-from pydantic_ai.models import ModelRequestContext
-
-hooks = Hooks()
-
-
-@hooks.on.before_model_request
-async def log_request(ctx: RunContext[None], request_context: ModelRequestContext) -> ModelRequestContext:
-    print(f'Sending {len(request_context.messages)} messages')
-    return request_context
-
-
-@hooks.on.before_tool_execute(tools=['send_email'])
-async def audit_tool(ctx, *, call, tool_def, args):
-    print(f'Executing {call.tool_name}')
-    return args
-
-
-agent = Agent('openai:gpt-5.2', capabilities=[hooks])
-```
-
-**Hook types:** `before_run`/`after_run`, `run` (wrap), `run_error`, `before_node_run`/`after_node_run`, `node_run` (wrap), `node_run_error`, `before_model_request`/`after_model_request`, `model_request` (wrap), `model_request_error`, `before_tool_validate`/`after_tool_validate`, `tool_validate` (wrap), `tool_validate_error`, `before_tool_execute`/`after_tool_execute`, `tool_execute` (wrap), `tool_execute_error`, `prepare_tools`, `run_event_stream`, `event`.
-
----
+Read [Intercept Agent Lifecycle with Hooks](./CAPABILITIES-AND-HOOKS.md#intercept-agent-lifecycle-with-hooks).
 
 ## Define Agents Declaratively with Specs
 
-Use YAML/JSON specs to separate agent configuration from application code. Specs support template strings rendered from dependencies at runtime.
-
-```yaml
-# agent.yaml
-model: anthropic:claude-opus-4-6
-instructions: "You are helping {{user_name}} with research."
-capabilities:
-  - WebSearch
-  - Thinking:
-      effort: high
-model_settings:
-  max_tokens: 8192
-```
-
-```python
-from dataclasses import dataclass
-
-from pydantic_ai import Agent
-
-
-@dataclass
-class UserContext:
-    user_name: str
-
-
-agent = Agent.from_file('agent.yaml', deps_type=UserContext)
-result = agent.run_sync('Find recent papers on AI safety', deps=UserContext(user_name='Alice'))
-```
-
-**Capability spec syntax:** `'WebSearch'` (no args), `{'Thinking': {'effort': 'high'}}` (kwargs), `{'Thinking': 'high'}` (single arg).
-
----
+Read [Define Agents Declaratively with Specs](./AGENTS-CORE.md#define-agents-declaratively-with-specs).
 
 ## Enable Thinking Across Providers
 
-Use the unified `Thinking` capability or `thinking` model setting for cross-provider reasoning support.
-
-```python
-from pydantic_ai import Agent
-from pydantic_ai.capabilities import Thinking
-
-# Via capability (recommended for spec compatibility)
-agent = Agent('anthropic:claude-opus-4-6', capabilities=[Thinking(effort='high')])
-
-# Via model_settings (equivalent)
-agent = Agent('anthropic:claude-opus-4-6', model_settings={'thinking': 'high'})
-```
-
-**Effort levels:** `True` (default effort), `False` (disable), `'minimal'`, `'low'`, `'medium'`, `'high'`, `'xhigh'`. Automatically mapped to each provider's native format (Anthropic adaptive thinking, OpenAI reasoning_effort, Google thinking_level, etc.).
-
----
+Read [Enable Thinking Across Providers](./CAPABILITIES-AND-HOOKS.md#enable-thinking-across-providers).
 
 ## Use MCP Servers
 
-Attach an MCP server as a toolset on the Agent. Use `MCPServerStdio` for subprocess-based servers or `MCPServerStreamableHTTP` for HTTP-based ones.
-
-```python
-from pydantic_ai import Agent
-from pydantic_ai.mcp import MCPServerStdio
-
-server = MCPServerStdio('python', args=['mcp_server.py'], timeout=10)
-agent = Agent('openai:gpt-5.2', toolsets=[server])
-
-async def main():
-    result = await agent.run('What is the weather in Paris?')
-    print(result.output)
-```
-
-**Gotcha:** Use `async with agent` (or `async with server`) for explicit lifecycle control. `MCPServerSSE` exists but is deprecated — prefer `MCPServerStreamableHTTP`.
-
----
+Read [Use MCP Servers](./TOOLS-CORE.md#use-mcp-servers).
 
 ## Search with DuckDuckGo, Tavily, or Exa
 
-Use `pydantic_ai.common_tools` for search-engine tools. DuckDuckGo is free; Tavily and Exa require API keys. Distinct from the `WebSearch` capability — these are explicit tool functions.
-
-```python
-from pydantic_ai import Agent
-from pydantic_ai.common_tools.duckduckgo import duckduckgo_search_tool
-
-agent = Agent(
-    'openai:gpt-5.2',
-    tools=[duckduckgo_search_tool()],
-    instructions='Search DuckDuckGo for the given query and return the results.',
-)
-
-result = agent.run_sync(
-    'Can you list the top five highest-grossing animated films of 2025?'
-)
-print(result.output)
-```
-
-**Install:** `uv add 'pydantic-ai-slim[duckduckgo]'` (or `[tavily]`/`[exa]`). For Tavily/Exa swap the import for `tavily_search_tool` / `ExaToolset`.
-
----
+Read [Search with DuckDuckGo, Tavily, or Exa](./TOOLS-CORE.md#search-with-duckduckgo-tavily-or-exa).
 
 ## Require Tool Approval (Human in the Loop)
 
-Use deferred tools to pause execution until external approval is granted. Mark a tool with `requires_approval=True`, then resume the run by passing `DeferredToolResults` back.
-
-```python
-from pydantic_ai import (
-    Agent,
-    DeferredToolRequests,
-    DeferredToolResults,
-    ToolDenied,
-)
-
-agent = Agent('openai:gpt-5.2', output_type=[str, DeferredToolRequests])
-
-@agent.tool_plain(requires_approval=True)
-def delete_file(path: str) -> str:
-    return f'File {path!r} deleted'
-
-result = agent.run_sync('Delete __init__.py')
-messages = result.all_messages()
-
-assert isinstance(result.output, DeferredToolRequests)
-results = DeferredToolResults()
-for call in result.output.approvals:
-    results.approvals[call.tool_call_id] = ToolDenied('Deleting files is not allowed')
-
-result = agent.run_sync('Continue', message_history=messages, deferred_tool_results=results)
-print(result.output)
-```
-
-**Gotcha:** `output_type` MUST include `DeferredToolRequests`. For conditional approval (only some calls need it), `raise ApprovalRequired(...)` from inside the tool instead of using `requires_approval=True`.
-
----
+Read [Require Tool Approval](./TOOLS-ADVANCED.md#require-tool-approval-human-in-the-loop).
 
 ## Send Images, Audio, Video, or Documents to the Model
 
-Pass multimodal content as a list mixing text with `ImageUrl`/`AudioUrl`/`VideoUrl`/`DocumentUrl` (URL-based) or `BinaryContent` (in-memory).
-
-```python
-from pydantic_ai import Agent, ImageUrl
-
-agent = Agent(model='openai:gpt-5.2')
-result = agent.run_sync(
-    [
-        'What company is this logo from?',
-        ImageUrl(url='https://iili.io/3Hs4FMg.png'),
-    ]
-)
-print(result.output)
-```
-
-**Gotcha:** Not all models support all input types — check provider documentation. `BinaryContent(data=..., media_type='image/png')` is the alternative for in-memory assets.
-
----
+Read [Send Images, Audio, Video, or Documents to the Model](./INPUT-AND-HISTORY.md#send-images-audio-video-or-documents-to-the-model).
 
 ## Manage Context Size
 
-Use `history_processors` to trim or filter messages before each model request.
-
-```python
-from pydantic_ai import Agent, ModelMessage
-
-
-async def keep_recent(messages: list[ModelMessage]) -> list[ModelMessage]:
-    return messages[-10:] if len(messages) > 10 else messages
-
-
-agent = Agent('openai:gpt-5.2', history_processors=[keep_recent])
-```
-
-**Also use for:** Privacy filtering (remove PII), summarizing old messages, role-based access.
-
----
+Read [Manage Context Size](./INPUT-AND-HISTORY.md#manage-context-size).
 
 ## Work with Message History
 
-Pass `result.new_messages()` from one run as `message_history=` to the next to continue a conversation across runs.
-
-```python
-from pydantic_ai import Agent
-
-agent = Agent('openai:gpt-5.2', instructions='Be a helpful assistant.')
-
-result1 = agent.run_sync('Tell me a joke.')
-print(result1.output)
-
-result2 = agent.run_sync('Explain?', message_history=result1.new_messages())
-print(result2.output)
-```
-
-**Gotcha:** `new_messages()` returns only the current run; `all_messages()` returns the full history. When `message_history=` is passed, no new system prompt is generated — the existing history is assumed to include one.
-
----
+Read [Work with Message History](./INPUT-AND-HISTORY.md#work-with-message-history).
 
 ## Show Real-Time Progress
 
-Use `event_stream_handler` with `run()` or `run_stream()` to receive events as they happen.
-
-```python
-from collections.abc import AsyncIterable
-
-from pydantic_ai import Agent, AgentStreamEvent, FunctionToolCallEvent, RunContext
-
-agent = Agent('openai:gpt-5.2')
-
-
-async def stream_handler(ctx: RunContext, events: AsyncIterable[AgentStreamEvent]):
-    async for event in events:
-        if isinstance(event, FunctionToolCallEvent):
-            print(f'Calling {event.part.tool_name}...')
-
-
-async def main():
-    await agent.run('Do the task', event_stream_handler=stream_handler)
-```
-
-**Also use for:** Logging, analytics, debugging, progress bars in UIs.
-
----
+Read [Run Methods and Streaming](./AGENTS-CORE.md#run-methods-and-streaming).
 
 ## Handle Provider Failures
 
-Use `FallbackModel` to automatically switch providers on 4xx/5xx errors.
-
-```python
-from pydantic_ai import Agent
-from pydantic_ai.models.anthropic import AnthropicModel
-from pydantic_ai.models.fallback import FallbackModel
-from pydantic_ai.models.openai import OpenAIChatModel
-
-fallback = FallbackModel(
-    OpenAIChatModel('gpt-5.2'),
-    AnthropicModel('claude-sonnet-4-6'),
-)
-agent = Agent(fallback)
-```
-
-**Also use for:** Cost optimization (expensive → cheap), rate limit handling, regional failover.
-
----
+Read [Handle Provider Failures](./AGENTS-CORE.md#handle-provider-failures).
 
 ## Make an Agent Resilient with Retries
 
-Raise `ModelRetry` from inside a tool to ask the model to call it again with corrected arguments. Set per-tool `retries=N` to override the Agent default.
-
-```python
-from pydantic_ai import Agent, RunContext, ModelRetry
-
-@agent.tool(retries=2)
-def get_user_by_name(ctx: RunContext[DatabaseConn], name: str) -> int:
-    user_id = ctx.deps.users.get(name=name)
-    if user_id is None:
-        raise ModelRetry(
-            f'No user found with name {name!r}, remember to provide their full name'
-        )
-    return user_id
-```
-
-**Gotcha:** Default is 1 retry. When the limit is exceeded and `ModelRetry` keeps firing, the agent raises `UnexpectedModelBehavior`. Current attempt is on `ctx.retry`.
-
----
+Read [Make an Agent Resilient with Retries](./TOOLS-ADVANCED.md#make-an-agent-resilient-with-retries).
 
 ## Debug a Failed Agent Run
 
-Wrap a run in `capture_run_messages()` and catch `UnexpectedModelBehavior` to inspect the full request/response history at the point of failure.
-
-```python
-from pydantic_ai import Agent, ModelRetry, UnexpectedModelBehavior, capture_run_messages
-
-with capture_run_messages() as messages:
-    try:
-        result = agent.run_sync('Please get me the volume of a box with size 6.')
-    except UnexpectedModelBehavior as e:
-        print('messages:', messages)
-```
-
-**Gotcha:** Captured messages include retries and tool-call attempts. Distinct from Logfire — use Logfire for production tracing, this for in-process debugging.
-
----
+Read [Debug a Failed Agent Run](./TESTING-AND-DEBUGGING.md#debug-a-failed-agent-run).
 
 ## Test Agent Behavior
 
-Use `TestModel` for fast deterministic tests; `FunctionModel` for custom response logic.
-
-```python
-from pydantic_ai import Agent
-from pydantic_ai.models.test import TestModel
-
-agent = Agent('openai:gpt-5.2')
-
-# TestModel: fast, auto-generates valid responses based on schema
-with agent.override(model=TestModel()):
-    result = agent.run_sync('test prompt')
-    assert result.output == 'success (no tool calls)'
-```
-
-```python
-from pydantic_ai import Agent, ModelResponse, TextPart
-from pydantic_ai.models.function import FunctionModel
-
-agent = Agent('openai:gpt-5.2')
-
-
-# FunctionModel: capture requests, return custom responses
-def custom_model(messages, info):
-    return ModelResponse(parts=[TextPart(content='mocked response')])
-
-
-with agent.override(model=FunctionModel(custom_model)):
-    result = agent.run_sync('test prompt')
-```
-
-**Also use for:** Capturing requests for assertions, simulating errors, testing retries.
-
----
+Read [Test Agent Behavior](./TESTING-AND-DEBUGGING.md#test-agent-behavior).
 
 ## Coordinate Multiple Agents
 
-Use **agent delegation** (via tools) when a child returns results to parent; **output functions** for permanent hand-offs.
-
-```python
-from pydantic_ai import Agent, RunContext
-
-parent = Agent('openai:gpt-5.2')
-researcher = Agent('openai:gpt-5.2', output_type=str)
-
-@parent.tool
-async def research(ctx: RunContext, topic: str) -> str:
-    """Delegate research to specialist."""
-    result = await researcher.run(f'Research: {topic}', usage=ctx.usage)
-    return result.output
-```
-
-**Also use for:** Triage/routing, specialist hand-off, graph-based workflows.
-
----
+Read [Coordinate Multiple Agents](./ORCHESTRATION-AND-INTEGRATIONS.md#coordinate-multiple-agents).
 
 ## Build Multi-Step Workflows with Graphs
 
-Use `pydantic_graph` (separate package, ships in the same monorepo) to define typed nodes and run them as a state machine. Outgoing edges are determined by `run()` return type annotations.
-
-```python
-from dataclasses import dataclass
-from pydantic_graph import BaseNode, End, Graph, GraphRunContext
-
-@dataclass
-class FirstNode(BaseNode[None, None, int]):
-    value: int
-
-    async def run(self, ctx: GraphRunContext) -> 'SecondNode | End[int]':
-        if self.value >= 5:
-            return End(self.value)
-        return SecondNode(self.value + 1)
-
-@dataclass
-class SecondNode(BaseNode):
-    value: int
-
-    async def run(self, ctx: GraphRunContext) -> FirstNode:
-        return FirstNode(self.value)
-
-graph = Graph(nodes=[FirstNode, SecondNode])
-result = graph.run_sync(FirstNode(0))
-```
-
-**Gotcha:** `End[T]` terminates the graph with output of type `T`.
-
----
+Read [Build Multi-Step Workflows with Graphs](./ORCHESTRATION-AND-INTEGRATIONS.md#build-multi-step-workflows-with-graphs).
 
 ## Debug and Validate Agent Behavior
 
-Instrument with Logfire to see exact model requests, tool calls, and validate LLM outputs. Each agent run becomes a parent trace with child spans for every tool call and LLM request.
-
-```python
-import logfire
-
-logfire.configure()
-logfire.instrument_pydantic_ai()
-
-# All agent runs now traced — see tool calls, model requests, and outputs in Logfire dashboard
-```
-
-For full HTTP-level visibility into what's sent to model providers (invaluable for debugging tool schema errors or unexpected model behavior):
-
-```python
-logfire.instrument_httpx(capture_all=True)
-```
-
-**Use for:** Debugging unexpected behavior, validating tool schemas, understanding what's sent to providers, production monitoring.
-
----
+Read [Debug and Validate Agent Behavior](./TESTING-AND-DEBUGGING.md#debug-and-validate-agent-behavior).
 
 ## Advanced and Less Common Features
 
-For features below, the offline reference is the relevant module in the locally-installed `pydantic_ai` package. Run `python -c "import pydantic_ai; print(pydantic_ai.__file__)"` to find the source root, then browse the listed module.
+Read only the relevant section in [ORCHESTRATION-AND-INTEGRATIONS.md](./ORCHESTRATION-AND-INTEGRATIONS.md):
 
-- **Embeddings for RAG** — `from pydantic_ai import Embedder` — `Embedder('openai:text-embedding-3-small')` exposes `embed_query()` for search queries and `embed_documents()` for content indexing.
-- **Direct API** — `from pydantic_ai.direct import model_request_sync, model_request` — call a model without constructing an `Agent`. Sync or async.
-- **A2A HTTP servers** — `agent.to_a2a()` returns an ASGI app implementing the A2A protocol. Run with uvicorn or any ASGI server.
-- **Durable Execution (Temporal)** — `from pydantic_ai.durable_exec.temporal import TemporalAgent, PydanticAIWorkflow, PydanticAIPlugin` — wrap an agent with `TemporalAgent()` to preserve progress across transient failures. DBOS and Prefect have parallel modules.
-- **LangChain tools** — `from pydantic_ai.ext.langchain import tool_from_langchain, LangChainToolset` — adapt individual tools or entire toolsets.
-- **ACI.dev tools** — `from pydantic_ai.ext.aci import tool_from_aci, ACIToolset`
-- **Custom toolsets / models / capabilities** — base classes: `AbstractToolset`/`WrapperToolset` from `pydantic_ai.toolsets`; `Model`/`WrapperModel` from `pydantic_ai.models`; `AbstractAgent`/`WrapperAgent` from `pydantic_ai.agent`; `AbstractCapability` from `pydantic_ai.capabilities`.
-- **Evaluations (`pydantic_evals`)** — `from pydantic_evals import Case, Dataset` and `from pydantic_evals.evaluators import IsInstance, Evaluator, EvaluatorContext` — separate package, install with `pip install pydantic-evals`.
-
----
+- [Direct API](./ORCHESTRATION-AND-INTEGRATIONS.md#call-the-model-without-using-an-agent)
+- [A2A](./ORCHESTRATION-AND-INTEGRATIONS.md#expose-agents-as-http-servers-a2a)
+- [Durable Execution](./ORCHESTRATION-AND-INTEGRATIONS.md#use-durable-execution)
+- [Embeddings](./ORCHESTRATION-AND-INTEGRATIONS.md#use-embeddings-for-rag)
+- [Third-Party Tools](./ORCHESTRATION-AND-INTEGRATIONS.md#use-langchain-or-acidev-tools)
+- [Custom Extensibility](./ORCHESTRATION-AND-INTEGRATIONS.md#build-custom-toolsets-models-or-agents)
+- [Evals](./ORCHESTRATION-AND-INTEGRATIONS.md#systematically-verify-agent-behavior-with-evals)
 
 ## Working with the Installed Pydantic AI Package
 
-Useful when the offline reference doesn't cover a specific symbol or you want to read source for an advanced feature.
+Prefer the checked-out repository or these bundled references first.
 
-- **Find the source root:** `python -c "import pydantic_ai; print(pydantic_ai.__file__)"` — browse the package directory for type stubs, docstrings, and submodule layout.
-- **Browse real-world examples:** `pip install pydantic-ai-examples`, then `python -c "import pydantic_ai_examples; print(pydantic_ai_examples.__file__)"`.
-- **Read the changelog:** the source tree contains `docs/changelog.md`. On PyPI, version history is on the project page.
-- **Install variants:** `pip install pydantic-ai` (full) or `pip install pydantic-ai-slim` with provider/feature extras like `[openai,duckduckgo,tavily]`.
+Inspect local package source only as a last resort when:
+
+- the user asks about a symbol that is not covered in this skill
+- the local environment already includes `pydantic_ai` and you need exact module layout
+- you have no narrower offline reference available

--- a/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
+++ b/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
@@ -1,0 +1,66 @@
+# Input and History
+
+Read this file when the user wants multimodal input, message history, or context trimming.
+
+## Send Images, Audio, Video, or Documents to the Model
+
+Pass multimodal content as a list mixing text with `ImageUrl`, `AudioUrl`, `VideoUrl`, `DocumentUrl`, or `BinaryContent`.
+
+```python
+from pydantic_ai import Agent, ImageUrl
+
+agent = Agent(model='openai:gpt-5.2')
+result = agent.run_sync(
+    [
+        'What company is this logo from?',
+        ImageUrl(url='https://example.com/logo.png'),
+    ]
+)
+print(result.output)
+```
+
+Use `BinaryContent(...)` when the asset is already in memory instead of at a URL.
+
+Not every model supports every input type. Keep provider expectations in mind when the user chooses a specific model.
+
+## Work with Message History
+
+Use `message_history=` to continue a conversation across runs.
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2', instructions='Be a helpful assistant.')
+
+result1 = agent.run_sync('Tell me a joke.')
+result2 = agent.run_sync('Explain?', message_history=result1.new_messages())
+print(result2.output)
+```
+
+Important distinctions:
+
+- `new_messages()` returns only the current run
+- `all_messages()` returns the full history accumulated so far
+- when `message_history` is non-empty, Pydantic AI assumes the history already carries the system prompt
+
+## Manage Context Size
+
+Use `history_processors=[...]` to trim or rewrite message history before each model request.
+
+```python
+from pydantic_ai import Agent, ModelMessage
+
+
+async def keep_recent(messages: list[ModelMessage]) -> list[ModelMessage]:
+    return messages[-10:] if len(messages) > 10 else messages
+
+
+agent = Agent('openai:gpt-5.2', history_processors=[keep_recent])
+```
+
+Good uses:
+
+- trimming long conversations
+- removing PII before provider calls
+- summarizing old messages
+- applying app-specific history policies

--- a/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
+++ b/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
@@ -1,0 +1,129 @@
+# Orchestration and Integrations
+
+Read this file when the user wants multi-agent coordination, graphs, direct model calls, A2A, durable execution, embeddings, evals, or third-party integrations.
+
+## Coordinate Multiple Agents
+
+Use agent delegation when one agent should call another and return the result.
+
+```python
+from pydantic_ai import Agent, RunContext
+
+parent = Agent('openai:gpt-5.2')
+researcher = Agent('openai:gpt-5.2', output_type=str)
+
+
+@parent.tool
+async def research(ctx: RunContext[None], topic: str) -> str:
+    result = await researcher.run(f'Research: {topic}', usage=ctx.usage)
+    return result.output
+```
+
+Good split:
+
+- delegation via tools when the parent keeps control
+- output functions or programmatic hand-off when control should move elsewhere
+
+## Build Multi-Step Workflows with Graphs
+
+Use `pydantic_graph` when the workflow is a state machine rather than a single agent loop.
+
+```python
+from dataclasses import dataclass
+
+from pydantic_graph import BaseNode, End, Graph, GraphRunContext
+
+
+@dataclass
+class FirstNode(BaseNode[None, None, int]):
+    value: int
+
+    async def run(self, ctx: GraphRunContext) -> 'SecondNode | End[int]':
+        if self.value >= 5:
+            return End(self.value)
+        return SecondNode(self.value + 1)
+
+
+@dataclass
+class SecondNode(BaseNode):
+    value: int
+
+    async def run(self, ctx: GraphRunContext) -> FirstNode:
+        return FirstNode(self.value)
+
+
+graph = Graph(nodes=[FirstNode, SecondNode])
+result = graph.run_sync(FirstNode(0))
+```
+
+## Call the Model Without Using an Agent
+
+Use the direct API when the user wants a single model request without agent orchestration.
+
+```python
+from pydantic_ai.direct import model_request_sync
+```
+
+Reach for this when there is no need for tools, retries, or agent loop state.
+
+## Expose Agents as HTTP Servers (A2A)
+
+Use `agent.to_a2a()` when the agent should be exposed as an ASGI app that speaks the A2A protocol.
+
+```python
+app = agent.to_a2a()
+```
+
+## Use Durable Execution
+
+Use the durable execution integrations when the run must survive crashes, retries, or long-lived workflows.
+
+Temporal entry points:
+
+- `TemporalAgent`
+- `PydanticAIWorkflow`
+- `PydanticAIPlugin`
+
+There are parallel integrations for DBOS and Prefect.
+
+## Use Embeddings for RAG
+
+Use `Embedder(...)` for query/document embeddings when the user is building retrieval or semantic search.
+
+```python
+from pydantic_ai import Embedder
+
+embedder = Embedder('openai:text-embedding-3-small')
+```
+
+## Use LangChain or ACI.dev Tools
+
+Third-party integrations to reach for:
+
+- `tool_from_langchain`
+- `LangChainToolset`
+- `tool_from_aci`
+- `ACIToolset`
+
+Use these when the user explicitly wants those ecosystems instead of native Pydantic AI tools.
+
+## Systematically Verify Agent Behavior with Evals
+
+Use `pydantic_evals` when the user wants repeatable evaluation datasets and evaluators rather than ad hoc tests.
+
+Common entry points:
+
+- `Case`
+- `Dataset`
+- evaluator classes from `pydantic_evals.evaluators`
+
+## Build Custom Toolsets, Models, or Agents
+
+Extensibility entry points:
+
+- `AbstractToolset` / `WrapperToolset`
+- `Model` / `WrapperModel`
+- `AbstractAgent` / `WrapperAgent`
+- `AbstractCapability`
+
+Reach for these only when the built-in primitives are genuinely insufficient.

--- a/skills/building-pydantic-ai-agents/references/TESTING-AND-DEBUGGING.md
+++ b/skills/building-pydantic-ai-agents/references/TESTING-AND-DEBUGGING.md
@@ -1,0 +1,75 @@
+# Testing and Debugging
+
+Read this file when the user wants deterministic tests, custom test models, request inspection, or runtime debugging.
+
+## Test Agent Behavior
+
+Use `TestModel` for fast deterministic tests and `FunctionModel` for custom response logic.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+agent = Agent('openai:gpt-5.2')
+
+with agent.override(model=TestModel()):
+    result = agent.run_sync('test prompt')
+    assert result.output == 'success (no tool calls)'
+```
+
+```python
+from pydantic_ai import Agent, ModelResponse, TextPart
+from pydantic_ai.models.function import FunctionModel
+
+agent = Agent('openai:gpt-5.2')
+
+
+def custom_model(messages, info):
+    return ModelResponse(parts=[TextPart(content='mocked response')])
+
+
+with agent.override(model=FunctionModel(custom_model)):
+    result = agent.run_sync('test prompt')
+```
+
+Default split:
+
+- `TestModel` when you want automatic valid outputs
+- `FunctionModel` when you need exact behavior for assertions, failures, or retries
+
+## Debug a Failed Agent Run
+
+Use `capture_run_messages()` when the user needs the exact request/response history that led to a failure.
+
+```python
+from pydantic_ai import Agent, UnexpectedModelBehavior, capture_run_messages
+
+agent = Agent('openai:gpt-5.2')
+
+with capture_run_messages() as messages:
+    try:
+        agent.run_sync('Please get me the volume of a box with size 6.')
+    except UnexpectedModelBehavior:
+        print(messages)
+```
+
+Use this for in-process debugging. It is a better fit than broad logging when the user wants to inspect one failing run.
+
+## Debug and Validate Agent Behavior
+
+Use Logfire when the user wants observability across agent runs, tools, and model requests.
+
+```python
+import logfire
+
+logfire.configure()
+logfire.instrument_pydantic_ai()
+logfire.instrument_httpx(capture_all=True)
+```
+
+Good uses:
+
+- tracing tool calls
+- validating what was sent to the provider
+- understanding structured-output failures
+- production observability

--- a/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
+++ b/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
@@ -1,0 +1,133 @@
+# Tools Advanced
+
+Read this file when the user wants advanced tool behavior: approval, retries, validation, timeouts, rich tool returns, or tool search/deferred loading.
+
+## Require Tool Approval (Human in the Loop)
+
+Use deferred tools when the run should pause for approval.
+
+```python
+from pydantic_ai import (
+    Agent,
+    DeferredToolRequests,
+    DeferredToolResults,
+    ToolDenied,
+)
+
+agent = Agent('openai:gpt-5.2', output_type=[str, DeferredToolRequests])
+
+
+@agent.tool_plain(requires_approval=True)
+def delete_file(path: str) -> str:
+    return f'File {path!r} deleted'
+
+
+result = agent.run_sync('Delete __init__.py')
+messages = result.all_messages()
+
+assert isinstance(result.output, DeferredToolRequests)
+results = DeferredToolResults()
+for call in result.output.approvals:
+    results.approvals[call.tool_call_id] = ToolDenied('Deleting files is not allowed')
+
+result = agent.run_sync('Continue', message_history=messages, deferred_tool_results=results)
+print(result.output)
+```
+
+Two key rules:
+
+- `DeferredToolRequests` must be in the output type
+- for conditional approval, raise `ApprovalRequired(...)` instead of marking the whole tool `requires_approval=True`
+
+## Make an Agent Resilient with Retries
+
+Raise `ModelRetry` from inside the tool when the model should correct and try again.
+
+```python
+from pydantic_ai import Agent, ModelRetry, RunContext
+
+agent = Agent('openai:gpt-5.2', deps_type=dict[str, int])
+
+
+@agent.tool(retries=2)
+def get_user_by_name(ctx: RunContext[dict[str, int]], name: str) -> int:
+    user_id = ctx.deps.get(name)
+    if user_id is None:
+        raise ModelRetry(f'No user found with name {name!r}')
+    return user_id
+```
+
+Use retries for recoverable model mistakes, not application crashes.
+
+## Validate or Require Approval Before Tool Execution
+
+Use `args_validator=` when arguments are structurally valid but still need business-rule validation before execution or approval.
+
+```python
+from pydantic_ai import Agent, DeferredToolRequests, ModelRetry, RunContext
+
+agent = Agent('openai:gpt-5.2', deps_type=int, output_type=[str, DeferredToolRequests])
+
+
+def validate_sum_limit(ctx: RunContext[int], x: int, y: int) -> None:
+    if x + y > ctx.deps:
+        raise ModelRetry(f'Sum of x and y must not exceed {ctx.deps}')
+
+
+@agent.tool(requires_approval=True, args_validator=validate_sum_limit)
+def add_numbers(ctx: RunContext[int], x: int, y: int) -> int:
+    return x + y
+```
+
+## Use Advanced Tool Features
+
+Reach for these features when the user needs more than a simple function tool:
+
+- `ToolReturn` for rich return values plus separate content/metadata
+- `prepare=` for dynamic tool definitions
+- `timeout=` for tool execution limits
+- `sequential=True` when tool calls must not run concurrently
+
+Example with `ToolReturn`:
+
+```python
+from pydantic_ai import Agent, BinaryContent, ToolReturn
+
+agent = Agent('openai:gpt-5.2')
+
+
+@agent.tool_plain
+def click_and_capture(x: int, y: int) -> ToolReturn:
+    return ToolReturn(
+        return_value=f'Successfully clicked at ({x}, {y})',
+        content=['After:', BinaryContent(data=b'png-data', media_type='image/png')],
+        metadata={'coordinates': {'x': x, 'y': y}},
+    )
+```
+
+## Handle Network Errors and Rate Limiting Automatically
+
+For tool-call retries, use `ModelRetry` and tool `retries=...`.
+
+For HTTP request retries at the transport layer, use the library's retry configuration separately. Do not assume `ModelRetry` alone solves provider transport failures.
+
+## Tool Search and Deferred Loading
+
+Use deferred loading when the agent has many tools and the model should discover them on demand via `search_tools`.
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+
+
+@agent.tool_plain(defer_loading=True)
+def lookup_internal_policy(policy_name: str) -> str:
+    return f'policy details for {policy_name}'
+```
+
+Good fit:
+
+- large MCP servers
+- big tool catalogs
+- situations where loading all tool schemas would bloat context

--- a/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
+++ b/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
@@ -1,0 +1,102 @@
+# Tools Core
+
+Read this file when the user wants to add function tools, organize toolsets, connect MCP servers, or use explicit common search tools.
+
+## Add Tools to an Agent
+
+Use `@agent.tool_plain` for pure functions and `@agent.tool` for tools that need `RunContext`.
+
+```python
+import random
+
+from pydantic_ai import Agent, RunContext
+
+agent = Agent('google-gla:gemini-3-flash-preview', deps_type=str)
+
+
+@agent.tool_plain
+def roll_dice() -> str:
+    return str(random.randint(1, 6))
+
+
+@agent.tool
+def get_player_name(ctx: RunContext[str]) -> str:
+    return ctx.deps
+```
+
+Use `Tool(fn)` when tools are defined outside the agent file or shared between agents.
+
+## Choosing a Tool Registration Method
+
+Default choices:
+
+- `@agent.tool` when the tool needs deps, usage, retry count, or message history
+- `@agent.tool_plain` when the tool is a plain function
+- `Tool(...)` in `tools=[...]` when the tool should be reusable across agents
+- `FunctionToolset` when multiple related tools should be managed as a group
+
+## Organize or Restrict Which Tools an Agent Can Use
+
+Use toolsets when the user has multiple related tools or wants cross-cutting behavior applied to a group.
+
+Examples:
+
+- `FunctionToolset` for a bundle of Python tools
+- MCP servers, which are themselves toolsets
+- wrapper toolsets for approval, deferred loading, or other cross-cutting behavior
+
+## Access Usage Stats, Message History, or Retry Count in Tools
+
+Route this to `@agent.tool` with `RunContext`.
+
+Useful `RunContext` fields include:
+
+- `ctx.deps`
+- `ctx.usage`
+- `ctx.messages`
+- `ctx.retry`
+
+## Use MCP Servers
+
+Attach an MCP server as a toolset on the agent.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPServerStdio
+
+server = MCPServerStdio('python', args=['mcp_server.py'], timeout=10)
+agent = Agent('openai:gpt-5.2', toolsets=[server])
+
+
+async def main():
+    async with agent:
+        result = await agent.run('What is the weather in Paris?')
+        print(result.output)
+```
+
+Default transport choices:
+
+- `MCPServerStdio` for local subprocess servers
+- `MCPServerStreamableHTTP` for HTTP servers
+
+`MCPServerSSE` still exists, but Streamable HTTP is the better default.
+
+## Search with DuckDuckGo, Tavily, or Exa
+
+Use common tools when the user wants explicit search tools rather than provider-adaptive capabilities.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.common_tools.duckduckgo import duckduckgo_search_tool
+
+agent = Agent(
+    'openai:gpt-5.2',
+    tools=[duckduckgo_search_tool()],
+    instructions='Search DuckDuckGo for the given query and return the results.',
+)
+```
+
+Good default split:
+
+- use `WebSearch()` capability when the user wants model-agnostic search with builtin fallback
+- use `duckduckgo_search_tool()` / Tavily / Exa when the user explicitly wants those engines as tools


### PR DESCRIPTION
Closes #6 

Users want the agents to not make web calls for skills. This moves those references to add examples inline.