### PR TITLE
Add automated upstream sync workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-skill-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify plugin and standalone skill copies are in sync
+        run: bash scripts/check-skill-sync.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
   check-skill-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Verify plugin and standalone skill copies are in sync
         run: bash scripts/check-skill-sync.sh

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -1,0 +1,50 @@
+name: Sync skills from upstream
+
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout aggregator
+        uses: actions/checkout@v4
+
+      - name: Run sync script
+        run: bash scripts/sync-from-upstream.sh
+
+      - name: Build PR body
+        id: body
+        run: |
+          {
+            echo "Automated sync of skill content from upstream source repositories."
+            echo
+            echo "## Upstream sources"
+            echo
+            cat /tmp/sync-summary.md
+            echo
+            echo "Review the diff against the listed upstream commits before merging."
+          } > /tmp/pr-body.md
+          {
+            echo 'body<<PRBODYEOF'
+            cat /tmp/pr-body.md
+            echo 'PRBODYEOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: autosync/upstream-skills
+          base: main
+          title: 'chore: sync skills from upstream'
+          body: ${{ steps.body.outputs.body }}
+          commit-message: 'chore: sync skills from upstream'
+          delete-branch: true
+          labels: autosync

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -9,9 +9,16 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: sync-from-upstream
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      SUMMARY_FILE: ${{ runner.temp }}/sync-summary.md
+      PR_BODY_FILE: ${{ runner.temp }}/pr-body.md
     steps:
       - name: Checkout aggregator
         uses: actions/checkout@v4
@@ -27,17 +34,18 @@ jobs:
             echo
             echo "## Upstream sources"
             echo
-            cat /tmp/sync-summary.md
+            cat "$SUMMARY_FILE"
             echo
             echo "Review the diff against the listed upstream commits before merging."
-          } > /tmp/pr-body.md
+          } > "$PR_BODY_FILE"
           {
             echo 'body<<PRBODYEOF'
-            cat /tmp/pr-body.md
+            cat "$PR_BODY_FILE"
             echo 'PRBODYEOF'
           } >> "$GITHUB_OUTPUT"
 
       - name: Create or update pull request
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -48,3 +56,13 @@ jobs:
           commit-message: 'chore: sync skills from upstream'
           delete-branch: true
           labels: autosync
+
+      # PRs opened by GITHUB_TOKEN don't trigger pull_request workflows
+      # (GitHub anti-recursion). workflow_dispatch is the documented exception,
+      # so we dispatch CI explicitly against the autosync branch's HEAD SHA;
+      # the resulting check_run attaches to the PR via SHA.
+      - name: Trigger CI on autosync PR
+        if: steps.cpr.outputs.pull-request-operation != 'none'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run ci.yml --ref autosync/upstream-skills --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -45,6 +45,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           existing_pr="$(
             gh pr list \
               --repo "$GITHUB_REPOSITORY" \
@@ -54,11 +59,6 @@ jobs:
               --json number \
               --jq '.[0].number // empty'
           )"
-
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -16,12 +17,9 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    env:
-      SUMMARY_FILE: ${{ runner.temp }}/sync-summary.md
-      PR_BODY_FILE: ${{ runner.temp }}/pr-body.md
     steps:
       - name: Checkout aggregator
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Run sync script
         run: bash scripts/sync-from-upstream.sh
@@ -34,19 +32,19 @@ jobs:
             echo
             echo "## Upstream sources"
             echo
-            cat "$SUMMARY_FILE"
+            cat "$RUNNER_TEMP/sync-summary.md"
             echo
             echo "Review the diff against the listed upstream commits before merging."
-          } > "$PR_BODY_FILE"
+          } > "$RUNNER_TEMP/pr-body.md"
           {
             echo 'body<<PRBODYEOF'
-            cat "$PR_BODY_FILE"
+            cat "$RUNNER_TEMP/pr-body.md"
             echo 'PRBODYEOF'
           } >> "$GITHUB_OUTPUT"
 
       - name: Create or update pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: autosync/upstream-skills

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -25,7 +25,6 @@ jobs:
         run: bash scripts/sync-from-upstream.sh
 
       - name: Build PR body
-        id: body
         run: |
           {
             echo "Automated sync of skill content from upstream source repositories."
@@ -36,31 +35,76 @@ jobs:
             echo
             echo "Review the diff against the listed upstream commits before merging."
           } > "$RUNNER_TEMP/pr-body.md"
-          {
-            echo 'body<<PRBODYEOF'
-            cat "$RUNNER_TEMP/pr-body.md"
-            echo 'PRBODYEOF'
-          } >> "$GITHUB_OUTPUT"
 
       - name: Create or update pull request
-        id: cpr
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6.1.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: autosync/upstream-skills
-          base: main
-          title: 'chore: sync skills from upstream'
-          body: ${{ steps.body.outputs.body }}
-          commit-message: 'chore: sync skills from upstream'
-          delete-branch: true
-          labels: autosync
+        id: sync-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BRANCH: autosync/upstream-skills
+          PR_TITLE: 'chore: sync skills from upstream'
+        run: |
+          set -euo pipefail
+
+          existing_pr="$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --head "$PR_BRANCH" \
+              --base main \
+              --state open \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+
+            if [ -n "$existing_pr" ]; then
+              gh pr close "$existing_pr" \
+                --repo "$GITHUB_REPOSITORY" \
+                --comment "Closing because upstream skills are already in sync with main." \
+                --delete-branch
+            elif git ls-remote --exit-code --heads origin "$PR_BRANCH" >/dev/null 2>&1; then
+              git push origin --delete "$PR_BRANCH"
+            fi
+
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$PR_BRANCH"
+          git add -A
+          git commit -m "chore: sync skills from upstream"
+
+          remote_sha="$(git ls-remote --heads origin "$PR_BRANCH" | awk '{print $1}')"
+          if [ -n "$remote_sha" ]; then
+            git push --force-with-lease="refs/heads/$PR_BRANCH:$remote_sha" origin "HEAD:$PR_BRANCH"
+          else
+            git push origin "HEAD:$PR_BRANCH"
+          fi
+
+          if [ -n "$existing_pr" ]; then
+            gh pr edit "$existing_pr" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$PR_TITLE" \
+              --body-file "$RUNNER_TEMP/pr-body.md"
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$PR_BRANCH" \
+              --title "$PR_TITLE" \
+              --body-file "$RUNNER_TEMP/pr-body.md"
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
 
       # PRs opened by GITHUB_TOKEN don't trigger pull_request workflows
       # (GitHub anti-recursion). workflow_dispatch is the documented exception,
       # so we dispatch CI explicitly against the autosync branch's HEAD SHA;
       # the resulting check_run attaches to the PR via SHA.
       - name: Trigger CI on autosync PR
-        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
+        if: steps.sync-pr.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run ci.yml --ref autosync/upstream-skills --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -57,16 +57,6 @@ jobs:
 
           if [ -z "$(git status --porcelain)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-
-            if [ -n "$existing_pr" ]; then
-              gh pr close "$existing_pr" \
-                --repo "$GITHUB_REPOSITORY" \
-                --comment "Closing because upstream skills are already in sync with main." \
-                --delete-branch
-            elif git ls-remote --exit-code --heads origin "$PR_BRANCH" >/dev/null 2>&1; then
-              git push origin --delete "$PR_BRANCH"
-            fi
-
             exit 0
           fi
 

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -60,7 +60,7 @@ jobs:
       # so we dispatch CI explicitly against the autosync branch's HEAD SHA;
       # the resulting check_run attaches to the PR via SHA.
       - name: Trigger CI on autosync PR
-        if: steps.cpr.outputs.pull-request-operation != 'none'
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run ci.yml --ref autosync/upstream-skills --repo "$GITHUB_REPOSITORY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,52 +1,26 @@
 # Contributing
 
-## Principle: skills live in the library they document
+## How this repo works
 
-Every skill in this marketplace is **owned by the package it documents**, not by this aggregator. Each library hosts its own skill in-tree under the conventional library-skills layout (`<package-dir>/.agents/skills/<skill-name>/`), and we mirror it here. This keeps three things true:
+Each skill is owned by the library it documents. Libraries host their skills at `<package-dir>/.agents/skills/<skill-name>/`; this repo is a thin aggregator that mirrors them to two destinations:
 
-- **One source of truth.** The library team reviews and ships the skill the same way they ship the rest of their code.
-- **No duplication or drift.** We do not maintain a parallel copy that can diverge from what the library ships.
-- **Two delivery channels from one source.** Users discover the skill via the library directly (agents that read `.agents/skills/`) *and* via this marketplace.
-
-This repo is a thin aggregator: it clones each upstream library, mirrors the skill directory, and republishes it as both a marketplace plugin and a standalone skill.
-
-## Where skill content lives in this repo
-
-Each synced skill is materialized in **two** locations here:
-
-- `plugins/<plugin>/skills/<skill>/` — consumed by the Claude Code plugin marketplace.
-- `skills/<skill>/` — the standalone copy distributed via the [agentskills.io](https://agentskills.io) standard.
-
-The two copies must stay byte-identical (they are mirrors of the same upstream). CI runs `scripts/check-skill-sync.sh` on every PR to enforce this.
-
-## Upstream is authoritative
-
-Skill content is **owned by the upstream source repository**, not by this aggregator:
+- `plugins/<plugin>/skills/<skill>/` — for the Claude Code plugin marketplace.
+- `skills/<skill>/` — the standalone copy for [agentskills.io](https://agentskills.io).
 
 | Skill | Upstream |
 |-------|----------|
 | `logfire-instrumentation` | [`pydantic/logfire`](https://github.com/pydantic/logfire) — `logfire/.agents/skills/logfire-instrumentation/` |
 | `building-pydantic-ai-agents` | [`pydantic/pydantic-ai`](https://github.com/pydantic/pydantic-ai) — `pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/` |
 
-A daily GitHub Actions job (`.github/workflows/sync-from-upstream.yml`) clones each upstream and runs `rsync -a --delete` from the upstream subpath into both the plugin and standalone destinations, then opens a PR titled `chore: sync skills from upstream`.
+A daily workflow (`.github/workflows/sync-from-upstream.yml`) clones each upstream, runs `rsync -a --delete` into both destinations, and opens a PR. CI (`scripts/check-skill-sync.sh`) enforces that the two destinations stay byte-identical.
 
-### What `--delete` means for you
-
-`rsync --delete` removes any file in the destination that is not present upstream. **Anything you add directly to `plugins/<plugin>/skills/<skill>/` or `skills/<skill>/` will be wiped on the next sync.** If you want to change skill content, send the PR to the upstream repo. The sync job will pick it up and propagate it here.
-
-The only files in this repo that are safe to edit by hand are:
-
-- `plugins/*/` plugin metadata (e.g. `.claude-plugin/plugin.json`, command files outside `skills/`).
-- Files at the repo root (`README.md`, `LICENSE`, `prek.toml`, `CONTRIBUTING.md`).
-- `.github/` workflows and `scripts/`.
+**Anything you add directly inside `plugins/*/skills/*/` or `skills/*/` will be wiped on the next sync.** To change skill content, send a PR upstream. Everything else in this repo (plugin metadata, repo-root files, `.github/`, `scripts/`) is fine to edit here.
 
 ## Adding a new skill
 
-A new skill always lands in its library's repo first, then gets wired up here:
-
-1. **The skill exists in the library** at `<package-dir>/.agents/skills/<skill-name>/`, following the library-skills layout (a `SKILL.md` plus any `references/...` it pulls in). That repo is the source of truth.
-2. **A `sync_skill` entry is added to `scripts/sync-from-upstream.sh`** here, pointing at the upstream repo, the upstream subpath, and the plugin + standalone destinations.
+1. Ensure the skill exists in the library at `<package-dir>/.agents/skills/<skill-name>/`.
+2. Add a `sync_skill` entry to `scripts/sync-from-upstream.sh`.
 
 ## Manually triggering a sync
 
-From the Actions tab, run **Sync skills from upstream** via `workflow_dispatch`. It will open (or update) the `autosync/upstream-skills` branch.
+Actions → **Sync skills from upstream** → Run workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+## Where skill content lives
+
+Each skill exists in **two** places in this repo:
+
+- `plugins/<plugin>/skills/<skill>/` — consumed by the Claude Code plugin marketplace.
+- `skills/<skill>/` — the standalone copy distributed via the [agentskills.io](https://agentskills.io) standard.
+
+The two copies must stay byte-identical. CI runs `scripts/check-skill-sync.sh` on every PR to enforce this.
+
+## Upstream is authoritative
+
+Skill content is **owned by the upstream source repository**, not by this aggregator:
+
+| Skill | Upstream |
+|-------|----------|
+| `logfire-instrumentation` | [`pydantic/logfire`](https://github.com/pydantic/logfire) — `logfire/.agents/skills/logfire-instrumentation/` |
+| `building-pydantic-ai-agents` | [`pydantic/pydantic-ai`](https://github.com/pydantic/pydantic-ai) — `pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/` |
+
+A daily GitHub Actions job (`.github/workflows/sync-from-upstream.yml`) clones each upstream and runs `rsync -a --delete` from the upstream subpath into both the plugin and standalone destinations, then opens a PR titled `chore: sync skills from upstream`.
+
+### What `--delete` means for you
+
+`rsync --delete` removes any file in the destination that is not present upstream. **Anything you add directly to `plugins/<plugin>/skills/<skill>/` or `skills/<skill>/` will be wiped on the next sync.** If you want to change skill content, send the PR to the upstream repo. The sync job will pick it up and propagate it here.
+
+The only files in this repo that are safe to edit by hand are:
+
+- `plugins/*/` plugin metadata (e.g. `.claude-plugin/plugin.json`, command files outside `skills/`).
+- Files at the repo root (`README.md`, `LICENSE`, `prek.toml`, `CONTRIBUTING.md`).
+- `.github/` workflows and `scripts/`.
+
+## Manually triggering a sync
+
+From the Actions tab, run **Sync skills from upstream** via `workflow_dispatch`. It will open (or update) the `autosync/upstream-skills` branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,23 @@
 # Contributing
 
-## Where skill content lives
+## Principle: skills live in the library they document
 
-Each skill exists in **two** places in this repo:
+Every skill in this marketplace is **owned by the package it documents**, not by this aggregator. Each library hosts its own skill in-tree under the conventional library-skills layout (`<package-dir>/.agents/skills/<skill-name>/`), and we mirror it here. This keeps three things true:
+
+- **One source of truth.** The library team reviews and ships the skill the same way they ship the rest of their code.
+- **No duplication or drift.** We do not maintain a parallel copy that can diverge from what the library ships.
+- **Two delivery channels from one source.** Users discover the skill via the library directly (agents that read `.agents/skills/`) *and* via this marketplace.
+
+This repo is a thin aggregator: it clones each upstream library, mirrors the skill directory, and republishes it as both a marketplace plugin and a standalone skill.
+
+## Where skill content lives in this repo
+
+Each synced skill is materialized in **two** locations here:
 
 - `plugins/<plugin>/skills/<skill>/` — consumed by the Claude Code plugin marketplace.
 - `skills/<skill>/` — the standalone copy distributed via the [agentskills.io](https://agentskills.io) standard.
 
-The two copies must stay byte-identical. CI runs `scripts/check-skill-sync.sh` on every PR to enforce this.
+The two copies must stay byte-identical (they are mirrors of the same upstream). CI runs `scripts/check-skill-sync.sh` on every PR to enforce this.
 
 ## Upstream is authoritative
 
@@ -29,6 +39,13 @@ The only files in this repo that are safe to edit by hand are:
 - `plugins/*/` plugin metadata (e.g. `.claude-plugin/plugin.json`, command files outside `skills/`).
 - Files at the repo root (`README.md`, `LICENSE`, `prek.toml`, `CONTRIBUTING.md`).
 - `.github/` workflows and `scripts/`.
+
+## Adding a new skill
+
+A new skill always lands in its library's repo first, then gets wired up here:
+
+1. **The skill exists in the library** at `<package-dir>/.agents/skills/<skill-name>/`, following the library-skills layout (a `SKILL.md` plus any `references/...` it pulls in). That repo is the source of truth.
+2. **A `sync_skill` entry is added to `scripts/sync-from-upstream.sh`** here, pointing at the upstream repo, the upstream subpath, and the plugin + standalone destinations.
 
 ## Manually triggering a sync
 

--- a/scripts/check-skill-sync.sh
+++ b/scripts/check-skill-sync.sh
@@ -1,93 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Ensure standalone skills/ copies stay in sync with plugin sources.
+# Ensure standalone skills/ copies stay byte-identical to plugin sources.
+#
+# Both copies are mechanically mirrored from upstream by sync-from-upstream.sh
+# (rsync -a --delete), so the invariant is "plugin dir == standalone dir".
+# A recursive diff enforces that without depending on a hand-curated file list,
+# which would go stale the moment upstream adds a new file.
 
 exit_code=0
 
-check_sync() {
-    local plugin_file="$1"
-    local standalone_file="$2"
+check_dir_sync() {
+    local plugin_dir="$1"
+    local standalone_dir="$2"
 
-    if [ ! -f "$standalone_file" ]; then
-        echo "MISSING: $standalone_file (should mirror $plugin_file)"
+    if [ ! -d "$plugin_dir" ]; then
+        echo "MISSING plugin dir: $plugin_dir"
         exit_code=1
         return
     fi
 
-    if ! diff -q "$plugin_file" "$standalone_file" > /dev/null 2>&1; then
-        echo "OUT OF SYNC: $standalone_file != $plugin_file"
-        echo "  Run: cp $plugin_file $standalone_file"
+    if [ ! -d "$standalone_dir" ]; then
+        echo "MISSING standalone dir: $standalone_dir (should mirror $plugin_dir)"
+        exit_code=1
+        return
+    fi
+
+    if ! diff -rq "$plugin_dir" "$standalone_dir"; then
+        echo "OUT OF SYNC: $standalone_dir does not match $plugin_dir"
+        echo "  Run: rsync -a --delete '$plugin_dir/' '$standalone_dir/'"
         exit_code=1
     fi
 }
 
-check_sync \
-    plugins/logfire/skills/logfire-instrumentation/SKILL.md \
-    skills/logfire-instrumentation/SKILL.md
+check_dir_sync \
+    plugins/logfire/skills/logfire-instrumentation \
+    skills/logfire-instrumentation
 
-check_sync \
-    plugins/logfire/skills/logfire-instrumentation/references/python/logging-patterns.md \
-    skills/logfire-instrumentation/references/python/logging-patterns.md
-
-check_sync \
-    plugins/logfire/skills/logfire-instrumentation/references/python/integrations.md \
-    skills/logfire-instrumentation/references/python/integrations.md
-
-check_sync \
-    plugins/logfire/skills/logfire-instrumentation/references/javascript/patterns.md \
-    skills/logfire-instrumentation/references/javascript/patterns.md
-
-check_sync \
-    plugins/logfire/skills/logfire-instrumentation/references/javascript/frameworks.md \
-    skills/logfire-instrumentation/references/javascript/frameworks.md
-
-check_sync \
-    plugins/logfire/skills/logfire-instrumentation/references/rust/patterns.md \
-    skills/logfire-instrumentation/references/rust/patterns.md
-
-check_sync \
-    plugins/ai/skills/building-pydantic-ai-agents/SKILL.md \
-    skills/building-pydantic-ai-agents/SKILL.md
-
-check_sync \
-    plugins/ai/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md \
-    skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
-
-check_sync \
-    plugins/ai/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md \
-    skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
-
-check_sync \
-    plugins/ai/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md \
-    skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
-
-check_sync \
-    plugins/ai/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md \
-    skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
-
-check_sync \
-    plugins/ai/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md \
-    skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
-
-check_sync \
-    plugins/ai/skills/building-pydantic-ai-agents/references/BUILTIN-TOOLS.md \
-    skills/building-pydantic-ai-agents/references/BUILTIN-TOOLS.md
-
-check_sync \
-    plugins/ai/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md \
-    skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
-
-check_sync \
-    plugins/ai/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md \
-    skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
-
-check_sync \
-    plugins/ai/skills/building-pydantic-ai-agents/references/TESTING-AND-DEBUGGING.md \
-    skills/building-pydantic-ai-agents/references/TESTING-AND-DEBUGGING.md
-
-check_sync \
-    plugins/ai/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md \
-    skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
+check_dir_sync \
+    plugins/ai/skills/building-pydantic-ai-agents \
+    skills/building-pydantic-ai-agents
 
 exit $exit_code

--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -11,10 +11,11 @@ set -euo pipefail
 # Paths are hardcoded on purpose. If upstream layout changes, this script must
 # be updated explicitly so the change goes through review.
 
-WORKDIR="$(mktemp -d)"
+TMP_BASE="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+WORKDIR="$(mktemp -d -p "$TMP_BASE")"
 trap 'rm -rf "$WORKDIR"' EXIT
 
-SUMMARY_FILE="${SUMMARY_FILE:-/tmp/sync-summary.md}"
+SUMMARY_FILE="${SUMMARY_FILE:-$TMP_BASE/sync-summary.md}"
 : > "$SUMMARY_FILE"
 
 sync_skill() {
@@ -40,6 +41,8 @@ sync_skill() {
         exit 1
     fi
 
+    # rsync --delete: plugin_dest and standalone_dest are mirrors of upstream;
+    # any local-only files there will be removed. See CONTRIBUTING.md.
     echo "Syncing $skill_name from $upstream_repo@${upstream_sha:0:7}"
     mkdir -p "$plugin_dest" "$standalone_dest"
     rsync -a --delete "$source_dir/" "$plugin_dest/"

--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sync skill content from upstream source repositories into this aggregator.
+#
+# Each entry below maps:
+#   <upstream repo> : <upstream subpath>
+#     -> <plugin destination>
+#     -> <standalone destination>
+#
+# Paths are hardcoded on purpose. If upstream layout changes, this script must
+# be updated explicitly so the change goes through review.
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+SUMMARY_FILE="${SUMMARY_FILE:-/tmp/sync-summary.md}"
+: > "$SUMMARY_FILE"
+
+sync_skill() {
+    local upstream_repo="$1"
+    local upstream_subpath="$2"
+    local plugin_dest="$3"
+    local standalone_dest="$4"
+    local skill_name="$5"
+
+    local clone_dir="$WORKDIR/$(echo "$upstream_repo" | tr '/' '_')"
+
+    if [ ! -d "$clone_dir" ]; then
+        echo "Cloning $upstream_repo..."
+        git clone --depth=1 "https://github.com/$upstream_repo.git" "$clone_dir"
+    fi
+
+    local upstream_sha
+    upstream_sha="$(git -C "$clone_dir" rev-parse HEAD)"
+
+    local source_dir="$clone_dir/$upstream_subpath"
+    if [ ! -d "$source_dir" ]; then
+        echo "ERROR: $upstream_repo:$upstream_subpath not found at HEAD ($upstream_sha)" >&2
+        exit 1
+    fi
+
+    echo "Syncing $skill_name from $upstream_repo@${upstream_sha:0:7}"
+    mkdir -p "$plugin_dest" "$standalone_dest"
+    rsync -a --delete "$source_dir/" "$plugin_dest/"
+    rsync -a --delete "$source_dir/" "$standalone_dest/"
+
+    printf -- '- **%s**: `%s@%s` (`%s`)\n' \
+        "$skill_name" "$upstream_repo" "${upstream_sha:0:7}" "$upstream_subpath" \
+        >> "$SUMMARY_FILE"
+}
+
+sync_skill \
+    "pydantic/logfire" \
+    "logfire/.agents/skills/logfire-instrumentation" \
+    "plugins/logfire/skills/logfire-instrumentation" \
+    "skills/logfire-instrumentation" \
+    "logfire-instrumentation"
+
+sync_skill \
+    "pydantic/pydantic-ai" \
+    "pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents" \
+    "plugins/ai/skills/building-pydantic-ai-agents" \
+    "skills/building-pydantic-ai-agents" \
+    "building-pydantic-ai-agents"
+
+echo
+echo "Sync complete. Summary:"
+cat "$SUMMARY_FILE"

--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -25,7 +25,8 @@ sync_skill() {
     local standalone_dest="$4"
     local skill_name="$5"
 
-    local clone_dir="$WORKDIR/$(echo "$upstream_repo" | tr '/' '_')"
+    local clone_dir
+    clone_dir="$WORKDIR/$(echo "$upstream_repo" | tr '/' '_')"
 
     if [ ! -d "$clone_dir" ]; then
         echo "Cloning $upstream_repo..."
@@ -48,7 +49,7 @@ sync_skill() {
     rsync -a --delete "$source_dir/" "$plugin_dest/"
     rsync -a --delete "$source_dir/" "$standalone_dest/"
 
-    printf -- '- **%s**: `%s@%s` (`%s`)\n' \
+    printf -- "- **%s**: \`%s@%s\` (\`%s\`)\n" \
         "$skill_name" "$upstream_repo" "${upstream_sha:0:7}" "$upstream_subpath" \
         >> "$SUMMARY_FILE"
 }

--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -30,7 +30,8 @@ sync_skill() {
 
     if [ ! -d "$clone_dir" ]; then
         echo "Cloning $upstream_repo..."
-        git clone --depth=1 "https://github.com/$upstream_repo.git" "$clone_dir"
+        git -c http.https://github.com/.extraheader= clone --depth=1 \
+            "https://github.com/$upstream_repo.git" "$clone_dir"
     fi
 
     local upstream_sha


### PR DESCRIPTION
Pulls skills from pydantic/logfire and pydantic/pydantic-ai on a daily cron (or via workflow_dispatch) and opens a PR for manual review.

Uses the default GITHUB_TOKEN scoped to contents:write and pull-requests:write on this repo only — no PATs, no GitHub App, and no credentials flow toward the source repos. Source repos are public and cloned anonymously.

Also adds a CI workflow that runs check-skill-sync.sh on every PR, so drift between plugin and standalone copies is caught before merge.