### PR TITLE
add skill for pydantic-ai-harness, specifically code mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Official [Claude Code](https://claude.com/claude-code) plugin marketplace for th
 |--------|-------------|----------|
 | [logfire](plugins/logfire/) | Add Logfire observability to Python apps | `/instrument`, `/debug`, `/query` |
 | [ai](plugins/ai/) | Build AI agents with Pydantic AI | — |
+| [harness](plugins/harness/) | Add additional capabilities to AI agents such as CodeMode | — |
 
 ## Install
 
@@ -22,6 +23,7 @@ Then install a plugin:
 ```
 claude plugin install logfire@pydantic-skills
 claude plugin install ai@pydantic-skills
+claude plugin install harness@pydantic-skills
 ```
 
 ## Cross-Agent Skills
@@ -32,6 +34,7 @@ The `skills/` directory contains standalone SKILL.md files compatible with 30+ a
 |-------|-------------|
 | [logfire-instrumentation](skills/logfire-instrumentation/) | Add Logfire observability to Python, JS/TS, and Rust apps |
 | [building-pydantic-ai-agents](skills/building-pydantic-ai-agents/) | Build LLM-powered agents with Pydantic AI — tools, capabilities, streaming, testing |
+| [pydantic-ai-harness](skills/pydantic-ai-harness/) | Extend Pydantic AI agents with additional capabilities: CodeMode |
 
 ## Development
 

--- a/plugins/harness/.claude-plugin/plugin.json
+++ b/plugins/harness/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "harness",
+  "description": "Add Pydantic AI Harness capabilities such as CodeMode for sandboxed tool orchestration in Pydantic AI agents",
+  "version": "0.1.0",
+  "author": {
+    "name": "Pydantic",
+    "email": "support@pydantic.dev"
+  }
+}

--- a/plugins/harness/README.md
+++ b/plugins/harness/README.md
@@ -1,0 +1,15 @@
+# harness
+
+Add [Pydantic AI Harness](https://github.com/pydantic/pydantic-ai-harness) capabilities to Pydantic AI agents.
+
+## Features
+
+- SKILL.md for [Pydantic AI Harness](https://github.com/pydantic/pydantic-ai-harness) usage patterns
+- Reference docs for `CodeMode`, including setup, sandboxing, YAML loading, and observability
+
+## Install
+
+```bash
+claude plugin marketplace add pydantic/skills
+claude plugin install harness@pydantic-skills
+```

--- a/plugins/harness/skills/pydantic-ai-harness/SKILL.md
+++ b/plugins/harness/skills/pydantic-ai-harness/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: pydantic-ai-harness
+description: >
+  Extend Pydantic AI agents with additional capabilities. The supported capability is `Code Mode` which provides
+  sandboxed python tool orchestration. Use when the user mentions executing agent written code, tool sandboxing, pydantic-ai-harness, CodeMode, Monty, or when a pydantic-ai agent would benefit from collapsing many tool calls into one sandboxed Python execution.
+license: MIT
+compatibility: Requires Python 3.10+ and pydantic-ai-slim>=1.80.0
+metadata:
+  version: "0.1.0"
+  author: pydantic
+---
+
+# Build with Pydantic AI Harness
+
+Pydantic AI Harness is a capability library for Pydantic AI agents. While core capabilities fundamental to all agents live in `pydantic-ai`, additional capabilities can be found here.
+
+## Supported Capabilities
+
+| Name | Description | Reference |
+| --- | --- | --- |
+| `code-mode` | Sandboxed python tool orchestration with `CodeMode()`| [Code Mode](./references/CODE-MODE.md) |
+
+## Install
+
+```bash
+uv add pydantic-ai-harness
+```
+
+Requires Python 3.10+ and `pydantic-ai-slim>=1.80.0`.
+
+## Extending pydantic-ai with pydantic-ai-harness Capabilities
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import MCP  # from the core pydantic-ai package
+from pydantic_ai_harness import CodeMode
+
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    capabilities=[
+        MCP('https://api.githubcopilot.com/mcp/'),
+        CodeMode(),
+    ],
+)
+
+result = agent.run_sync('Rank the open PRs on pydantic/pydantic-ai-harness by thumbs-up reactions. Which 5 should we merge first?')
+print(result.output)
+```
+
+The `MCP` capability continues to come from the core `pydantic-ai` package.
+
+An additional capability, `CodeMode` from pydantic-ai-harness, consolidates all tools into a single run_code tool, allowing the model to coordinate multiple tool calls via Python rather than requiring a separate model round‑trip for each call.
+
+## Key Practices
+
+- Confirm the task actually needs a capability from pydantic-ai-harness. If ordinary Pydantic AI tools or capabilities are enough, use the core Pydantic AI skill instead.
+- Identify which capability is needed and read the applicable reference document before writing code.

--- a/plugins/harness/skills/pydantic-ai-harness/references/CODE-MODE.md
+++ b/plugins/harness/skills/pydantic-ai-harness/references/CODE-MODE.md
@@ -1,0 +1,160 @@
+# Code Mode
+
+Standard tool calling takes one model round-trip per tool call. `CodeMode` wraps eligible tools into a
+single `run_code` tool so the LLM can write Python that loops, branches, aggregates, and parallelizes tool work inside a sandbox.
+
+Use it when the agent needs to call several tools, transform intermediate results, run concurrent
+tool work with `asyncio.gather`, or anywhere that a simple Python script is more reliable than an LLM, such as in mathematics.
+
+## Install
+
+```bash
+uv add "pydantic-ai-harness[codemode]"
+```
+
+## Basic Pattern
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import CodeMode
+
+agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[CodeMode()])
+
+
+@agent.tool_plain
+def get_weather(city: str) -> dict:
+    return {'city': city, 'temp_f': 72, 'condition': 'sunny'}
+
+
+@agent.tool_plain
+def convert_temp(fahrenheit: float) -> float:
+    return round((fahrenheit - 32) * 5 / 9, 1)
+```
+
+The LLM could be prompted to generate code like:
+
+```python
+paris, tokyo = await asyncio.gather(
+    get_weather(city='Paris'),
+    get_weather(city='Tokyo'),
+)
+paris_c = await convert_temp(fahrenheit=paris['temp_f'])
+tokyo_c = await convert_temp(fahrenheit=tokyo['temp_f'])
+{'paris': paris_c, 'tokyo': tokyo_c}
+```
+
+This reduces four LLM calls to one.
+
+## Choose Which Tools Are Sandboxed
+
+The `tools` parameter controls which tools move behind `run_code`.
+
+```python
+from pydantic_ai_harness import CodeMode
+
+CodeMode(tools='all')
+CodeMode(tools=['search', 'fetch'])
+CodeMode(tools=lambda ctx, td: td.name != 'dangerous_tool')
+CodeMode(tools={'code_mode': True})
+```
+
+Metadata-based selection is useful when the project already groups tools into toolsets:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.toolsets import FunctionToolset
+from pydantic_ai_harness import CodeMode
+
+search_tools = FunctionToolset(tools=[search, fetch]).with_metadata(code_mode=True)
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    toolsets=[search_tools],
+    capabilities=[CodeMode(tools={'code_mode': True})],
+)
+```
+
+Non-matching tools remain regular tool calls.
+
+## Return Values
+
+`run_code` captures the last expression automatically.
+
+| Scenario | Return |
+| --- | --- |
+| No print output | Last expression value |
+| With print output | `{"output": "<printed text>", "result": <last expression>}` |
+| Multimodal content | Returned natively for model processing |
+
+If the user expects a raw dict or list back, avoid unnecessary `print()` statements.
+
+## Retries
+
+```python
+CodeMode(
+    tools='all',
+    max_retries=3,
+)
+```
+
+Use `max_retries` when sandbox execution errors are expected to be recoverable.
+If the generated code fails during sandbox execution, the error message is sent back to the LLM, and the model is asked to redraft the code in light of that failure. This process is repeated up to `max_retries` times, or until the code executes
+
+## REPL State
+
+State persists between `run_code` calls during the same agent run. Imports, variables, and helper
+functions carry over until the run ends. Use `restart: true` in the tool call to reset state when the
+conversation has drifted or stale state is causing wrong behavior.
+
+## Sandbox Restrictions
+
+Code runs inside Monty, an implementation of Python which intentionally supports only a subset of features.
+
+Key restrictions:
+
+- No class definitions
+- No third-party imports
+- No `import *`
+- Only a small stdlib subset is allowed: `sys`, `typing`, `asyncio`, `math`, `json`, `re`, `datetime`, `os`, `pathlib`
+- Tools that need approval or deferred execution are excluded from the sandbox
+
+When a generated example keeps failing, check these restrictions before changing the rest of the agent.
+
+## Agent Specs
+
+When the user defines the agent in YAML or JSON, the loader needs to know how to build `CodeMode`:
+
+```yaml
+model: anthropic:claude-sonnet-4-6
+capabilities:
+  - CodeMode: {}
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import CodeMode
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[CodeMode])
+```
+
+The same pattern applies when passing arguments:
+
+```yaml
+capabilities:
+  - CodeMode:
+      tools: ['search', 'fetch']
+      max_retries: 5
+```
+
+## Observability
+
+With Logfire or another OpenTelemetry backend, nested tool calls inside `run_code` produce child spans.
+That makes CodeMode much easier to debug than a plain blob of generated code.
+
+```python
+for msg in result.all_messages():
+    for part in msg.parts:
+        if isinstance(part, ToolReturnPart) and part.tool_name == 'run_code':
+            tool_calls = part.metadata['tool_calls']    # dict[str, ToolCallPart]
+            tool_returns = part.metadata['tool_returns'] # dict[str, ToolReturnPart]
+```

--- a/scripts/check-skill-sync.sh
+++ b/scripts/check-skill-sync.sh
@@ -102,4 +102,16 @@ check_sync \
     plugins/ai/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md \
     skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
 
+check_sync \
+    plugins/harness/skills/pydantic-ai-harness/SKILL.md \
+    skills/pydantic-ai-harness/SKILL.md
+
+check_sync \
+    plugins/harness/skills/pydantic-ai-harness/references/CODE-MODE.md \
+    skills/pydantic-ai-harness/references/CODE-MODE.md
+
+check_sync \
+    plugins/harness/skills/pydantic-ai-harness/evals/evals.json \
+    skills/pydantic-ai-harness/evals/evals.json
+
 exit $exit_code

--- a/scripts/check-skill-sync.sh
+++ b/scripts/check-skill-sync.sh
@@ -110,8 +110,4 @@ check_sync \
     plugins/harness/skills/pydantic-ai-harness/references/CODE-MODE.md \
     skills/pydantic-ai-harness/references/CODE-MODE.md
 
-check_sync \
-    plugins/harness/skills/pydantic-ai-harness/evals/evals.json \
-    skills/pydantic-ai-harness/evals/evals.json
-
 exit $exit_code

--- a/skills/pydantic-ai-harness/SKILL.md
+++ b/skills/pydantic-ai-harness/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: pydantic-ai-harness
+description: >
+  Extend Pydantic AI agents with additional capabilities. The supported capability is `Code Mode` which provides
+  sandboxed python tool orchestration. Use when the user mentions executing agent written code, tool sandboxing, pydantic-ai-harness, CodeMode, Monty, or when a pydantic-ai agent would benefit from collapsing many tool calls into one sandboxed Python execution.
+license: MIT
+compatibility: Requires Python 3.10+ and pydantic-ai-slim>=1.80.0
+metadata:
+  version: "0.1.0"
+  author: pydantic
+---
+
+# Build with Pydantic AI Harness
+
+Pydantic AI Harness is a capability library for Pydantic AI agents. While core capabilities fundamental to all agents live in `pydantic-ai`, additional capabilities can be found here.
+
+## Supported Capabilities
+
+| Name | Description | Reference |
+| --- | --- | --- |
+| `code-mode` | Sandboxed python tool orchestration with `CodeMode()`| [Code Mode](./references/CODE-MODE.md) |
+
+## Install
+
+```bash
+uv add pydantic-ai-harness
+```
+
+Requires Python 3.10+ and `pydantic-ai-slim>=1.80.0`.
+
+## Extending pydantic-ai with pydantic-ai-harness Capabilities
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import MCP  # from the core pydantic-ai package
+from pydantic_ai_harness import CodeMode
+
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    capabilities=[
+        MCP('https://api.githubcopilot.com/mcp/'),
+        CodeMode(),
+    ],
+)
+
+result = agent.run_sync('Rank the open PRs on pydantic/pydantic-ai-harness by thumbs-up reactions. Which 5 should we merge first?')
+print(result.output)
+```
+
+The `MCP` capability continues to come from the core `pydantic-ai` package.
+
+An additional capability, `CodeMode` from pydantic-ai-harness, consolidates all tools into a single run_code tool, allowing the model to coordinate multiple tool calls via Python rather than requiring a separate model round‑trip for each call.
+
+## Key Practices
+
+- Confirm the task actually needs a capability from pydantic-ai-harness. If ordinary Pydantic AI tools or capabilities are enough, use the core Pydantic AI skill instead.
+- Identify which capability is needed and read the applicable reference document before writing code.

--- a/skills/pydantic-ai-harness/references/CODE-MODE.md
+++ b/skills/pydantic-ai-harness/references/CODE-MODE.md
@@ -1,0 +1,160 @@
+# Code Mode
+
+Standard tool calling takes one model round-trip per tool call. `CodeMode` wraps eligible tools into a
+single `run_code` tool so the LLM can write Python that loops, branches, aggregates, and parallelizes tool work inside a sandbox.
+
+Use it when the agent needs to call several tools, transform intermediate results, run concurrent
+tool work with `asyncio.gather`, or anywhere that a simple Python script is more reliable than an LLM, such as in mathematics.
+
+## Install
+
+```bash
+uv add "pydantic-ai-harness[codemode]"
+```
+
+## Basic Pattern
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import CodeMode
+
+agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[CodeMode()])
+
+
+@agent.tool_plain
+def get_weather(city: str) -> dict:
+    return {'city': city, 'temp_f': 72, 'condition': 'sunny'}
+
+
+@agent.tool_plain
+def convert_temp(fahrenheit: float) -> float:
+    return round((fahrenheit - 32) * 5 / 9, 1)
+```
+
+The LLM could be prompted to generate code like:
+
+```python
+paris, tokyo = await asyncio.gather(
+    get_weather(city='Paris'),
+    get_weather(city='Tokyo'),
+)
+paris_c = await convert_temp(fahrenheit=paris['temp_f'])
+tokyo_c = await convert_temp(fahrenheit=tokyo['temp_f'])
+{'paris': paris_c, 'tokyo': tokyo_c}
+```
+
+This reduces four LLM calls to one.
+
+## Choose Which Tools Are Sandboxed
+
+The `tools` parameter controls which tools move behind `run_code`.
+
+```python
+from pydantic_ai_harness import CodeMode
+
+CodeMode(tools='all')
+CodeMode(tools=['search', 'fetch'])
+CodeMode(tools=lambda ctx, td: td.name != 'dangerous_tool')
+CodeMode(tools={'code_mode': True})
+```
+
+Metadata-based selection is useful when the project already groups tools into toolsets:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.toolsets import FunctionToolset
+from pydantic_ai_harness import CodeMode
+
+search_tools = FunctionToolset(tools=[search, fetch]).with_metadata(code_mode=True)
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    toolsets=[search_tools],
+    capabilities=[CodeMode(tools={'code_mode': True})],
+)
+```
+
+Non-matching tools remain regular tool calls.
+
+## Return Values
+
+`run_code` captures the last expression automatically.
+
+| Scenario | Return |
+| --- | --- |
+| No print output | Last expression value |
+| With print output | `{"output": "<printed text>", "result": <last expression>}` |
+| Multimodal content | Returned natively for model processing |
+
+If the user expects a raw dict or list back, avoid unnecessary `print()` statements.
+
+## Retries
+
+```python
+CodeMode(
+    tools='all',
+    max_retries=3,
+)
+```
+
+Use `max_retries` when sandbox execution errors are expected to be recoverable.
+If the generated code fails during sandbox execution, the error message is sent back to the LLM, and the model is asked to redraft the code in light of that failure. This process is repeated up to `max_retries` times, or until the code executes
+
+## REPL State
+
+State persists between `run_code` calls during the same agent run. Imports, variables, and helper
+functions carry over until the run ends. Use `restart: true` in the tool call to reset state when the
+conversation has drifted or stale state is causing wrong behavior.
+
+## Sandbox Restrictions
+
+Code runs inside Monty, an implementation of Python which intentionally supports only a subset of features.
+
+Key restrictions:
+
+- No class definitions
+- No third-party imports
+- No `import *`
+- Only a small stdlib subset is allowed: `sys`, `typing`, `asyncio`, `math`, `json`, `re`, `datetime`, `os`, `pathlib`
+- Tools that need approval or deferred execution are excluded from the sandbox
+
+When a generated example keeps failing, check these restrictions before changing the rest of the agent.
+
+## Agent Specs
+
+When the user defines the agent in YAML or JSON, the loader needs to know how to build `CodeMode`:
+
+```yaml
+model: anthropic:claude-sonnet-4-6
+capabilities:
+  - CodeMode: {}
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import CodeMode
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[CodeMode])
+```
+
+The same pattern applies when passing arguments:
+
+```yaml
+capabilities:
+  - CodeMode:
+      tools: ['search', 'fetch']
+      max_retries: 5
+```
+
+## Observability
+
+With Logfire or another OpenTelemetry backend, nested tool calls inside `run_code` produce child spans.
+That makes CodeMode much easier to debug than a plain blob of generated code.
+
+```python
+for msg in result.all_messages():
+    for part in msg.parts:
+        if isinstance(part, ToolReturnPart) and part.tool_name == 'run_code':
+            tool_calls = part.metadata['tool_calls']    # dict[str, ToolCallPart]
+            tool_returns = part.metadata['tool_returns'] # dict[str, ToolReturnPart]
+```


### PR DESCRIPTION
## What
Adds a skill for using `pydantic-ai-harness`, with a reference for code mode. Resolves #12

## Why
Code mode is one of the most exciting new capabilities in `pydantic-ai`. This skill enables Claude and other coding LLM tools to use it.

## Notes
- Added separately from the core `pydantic-ai` skill to align with `library-skills` conventions.
- Since `pydantic-ai-harness` currently exposes only one capability, it’s unclear whether this should be a code-mode-only skill or a broader harness skill that references code mode. I chose the broader approach to make it easier to extend as additional capabilities are added.
- Content largely based on the `pydantic-ai-harness`[README.md](https://github.com/pydantic/pydantic-ai-harness/blob/main/README.md) and the Code Mode [README.md](https://github.com/pydantic/pydantic-ai-harness/blob/main/pydantic_ai_harness/code_mode/README.md).