### PR TITLE
Add pydantic-ai-harness skill sync and marketplace plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,6 +29,18 @@
       "source": "./plugins/ai",
       "category": "development",
       "homepage": "https://github.com/pydantic/skills/tree/main/plugins/ai"
+    },
+    {
+      "name": "pydantic-ai-harness",
+      "description": "Extend Pydantic AI agents with batteries-included capabilities from pydantic-ai-harness, currently Code Mode for collapsing many tool calls into one sandboxed Python execution",
+      "version": "0.1.0",
+      "author": {
+        "name": "Pydantic",
+        "email": "support@pydantic.dev"
+      },
+      "source": "./plugins/pydantic-ai-harness",
+      "category": "development",
+      "homepage": "https://github.com/pydantic/skills/tree/main/plugins/pydantic-ai-harness"
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Synced skills are owned by the library they document. Libraries host those skill
 |-------|----------|
 | `logfire-instrumentation` | [`pydantic/logfire`](https://github.com/pydantic/logfire) — `logfire/.agents/skills/logfire-instrumentation/` |
 | `building-pydantic-ai-agents` | [`pydantic/pydantic-ai`](https://github.com/pydantic/pydantic-ai) — `pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/` |
+| `pydantic-ai-harness` | [`pydantic/pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness) — `pydantic_ai_harness/.agents/skills/pydantic-ai-harness/` |
 
 A daily workflow (`.github/workflows/sync-from-upstream.yml`) clones each upstream listed above, runs `rsync -a --delete` into both destinations, and opens a PR. CI (`scripts/check-skill-sync.sh`) enforces that plugin and standalone skill copies stay byte-identical.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Logfire and Pydantic AI plugins for [Claude Code](https://claude.com/claude-code
 | [logfire](plugins/logfire/)                   | Claude Code, Codex, Cursor | Add Logfire observability and query/debug telemetry | Claude commands `/instrument`, `/debug`, `/query`; Codex/Cursor skills and MCP tools |
 | [logfire-exporter](plugins/logfire-exporter/) | Codex                      | Export Codex activity traces to Logfire             | Codex lifecycle hooks                                                                |
 | [ai](plugins/ai/)                             | Claude Code                | Build AI agents with Pydantic AI                    | Pydantic AI skill docs                                                               |
+| [pydantic-ai-harness](plugins/pydantic-ai-harness/) | Claude Code          | Extend Pydantic AI agents with harness capabilities (Code Mode) | Pydantic AI Harness skill docs                                           |
 
 ## Install In Claude Code
 
@@ -23,6 +24,7 @@ Then install a plugin:
 ```
 claude plugin install logfire@pydantic-skills
 claude plugin install ai@pydantic-skills
+claude plugin install pydantic-ai-harness@pydantic-skills
 ```
 
 ## Install In Codex
@@ -81,3 +83,4 @@ The `skills/` directory contains standalone SKILL.md files compatible with 30+ a
 | [logfire-query](skills/logfire-query/)                             | Query and analyze Logfire traces, logs, spans, metrics, and activity data           |
 | [logfire-ui](skills/logfire-ui/)                                   | Open Logfire project pages, live views, traces, and Explore filters                 |
 | [building-pydantic-ai-agents](skills/building-pydantic-ai-agents/) | Build LLM-powered agents with Pydantic AI — tools, capabilities, streaming, testing |
+| [pydantic-ai-harness](skills/pydantic-ai-harness/)                 | Extend Pydantic AI agents with harness capabilities like Code Mode (sandboxed `run_code`) |

--- a/plugins/pydantic-ai-harness/.claude-plugin/plugin.json
+++ b/plugins/pydantic-ai-harness/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "pydantic-ai-harness",
+  "description": "Extend Pydantic AI agents with batteries-included capabilities from pydantic-ai-harness, currently Code Mode for collapsing many tool calls into one sandboxed Python execution",
+  "version": "0.1.0",
+  "author": {
+    "name": "Pydantic",
+    "email": "support@pydantic.dev"
+  }
+}

--- a/plugins/pydantic-ai-harness/README.md
+++ b/plugins/pydantic-ai-harness/README.md
@@ -1,0 +1,23 @@
+# pydantic-ai-harness
+
+Extend [Pydantic AI](https://ai.pydantic.dev/) agents with batteries-included capabilities from
+[pydantic-ai-harness](https://github.com/pydantic/pydantic-ai-harness).
+
+## Features
+
+- SKILL.md covering the harness capability model (`capabilities=[...]`)
+- Reference docs for Code Mode — wrapping eligible tools into a single sandboxed `run_code` tool so the model orchestrates many tool calls in one Python execution
+
+For the core framework (agents, tools, structured output, streaming, testing), use the `ai` plugin.
+
+## Install
+
+```bash
+claude plugin marketplace add pydantic/skills
+claude plugin install pydantic-ai-harness@pydantic-skills
+```
+
+## Codex
+
+`pydantic-ai-harness` is not currently listed as a Codex plugin in the Pydantic marketplace. Codex users can
+still use the standalone cross-agent skill at `skills/pydantic-ai-harness/`.

--- a/plugins/pydantic-ai-harness/skills/pydantic-ai-harness/SKILL.md
+++ b/plugins/pydantic-ai-harness/skills/pydantic-ai-harness/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: pydantic-ai-harness
+description: Extend Pydantic AI agents with batteries-included capabilities from pydantic-ai-harness — currently Code Mode, which collapses many tool calls into one sandboxed Python execution. Use when the user mentions pydantic-ai-harness, CodeMode, Monty, code mode, or tool sandboxing, when they want an agent to run agent-written Python, or when a Pydantic AI agent would benefit from orchestrating multiple tool calls in a single sandboxed script.
+license: MIT
+compatibility: Requires Python 3.10+ and pydantic-ai-slim>=1.95.1
+metadata:
+  version: "0.1.0"
+  author: pydantic
+---
+
+# Building with Pydantic AI Harness
+
+Pydantic AI Harness is the official capability library for Pydantic AI. Capabilities that need model or
+framework support — and those fundamental to every agent — live in core `pydantic-ai`; optional,
+batteries-included capabilities live here. Both are composed onto an agent through the same
+`capabilities=[...]` API.
+
+This skill covers the capabilities shipped by `pydantic-ai-harness`. For the core framework — agents,
+tools, structured output, hooks, and testing — use the `building-pydantic-ai-agents` skill instead.
+
+## When to Use This Skill
+
+Invoke this skill when:
+- The user mentions `pydantic-ai-harness`, `CodeMode`, code mode, or the Monty sandbox
+- An agent makes many sequential tool calls that could collapse into one sandboxed Python execution
+- The user wants the model to write Python that loops, branches, aggregates, or parallelizes tool calls with `asyncio.gather`
+- The user asks to sandbox or constrain the code an agent runs
+
+Do **not** use this skill for:
+- Core Pydantic AI usage — building agents, adding tools, structured output, streaming, or testing (use `building-pydantic-ai-agents`)
+- Capabilities that ship in core `pydantic-ai`, such as web search, tool search, and thinking
+- The Pydantic validation library on its own (`pydantic`/`BaseModel` without agents)
+
+## Supported Capabilities
+
+| Capability | Description | Reference |
+|---|---|---|
+| `CodeMode` | Wraps eligible tools into a single sandboxed `run_code` tool so the model orchestrates them in Python | [Code Mode](./references/CODE-MODE.md) |
+
+More capability areas are tracked in the
+[capability matrix](https://github.com/pydantic/pydantic-ai-harness#capability-matrix); as they stabilize,
+this skill grows to cover them.
+
+## Install
+
+```bash
+uv add pydantic-ai-harness
+```
+
+Each capability declares its own extra. Code Mode needs the Monty sandbox:
+
+```bash
+uv add "pydantic-ai-harness[codemode]"   # `code-mode` is also accepted as an alias
+```
+
+Requires Python 3.10+ and `pydantic-ai-slim>=1.95.1`.
+
+## Quick Start
+
+A harness capability is added to the agent like any other. Here `CodeMode` wraps an MCP server's tools into
+a single `run_code` tool that the model drives with Python.
+
+```python {test="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import MCP  # MCP ships in core pydantic-ai
+
+from pydantic_ai_harness import CodeMode
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    capabilities=[
+        # native=False routes the MCP tools through a local toolset so CodeMode can wrap them.
+        # Without it, providers with native MCP run the tools server-side and bypass the sandbox.
+        MCP('https://hn.caseyjhand.com/mcp', native=False),
+        CodeMode(),
+    ],
+)
+
+result = agent.run_sync(
+    'Across the top and best Hacker News feeds, find the most-discussed story with at '
+    'least 100 points and summarize its comment thread in one paragraph.'
+)
+print(result.output)
+#> The most-discussed story clearing 100 points is ...
+```
+
+Instead of one model round-trip per tool call, the model writes a single Python script that fetches both
+feeds with `asyncio.gather`, dedupes and ranks them in plain Python, and pulls the winning thread —
+collapsing many calls into one `run_code`.
+
+## Key Practices
+
+- **Confirm a harness capability is actually needed.** If core Pydantic AI tools and capabilities are enough, use the `building-pydantic-ai-agents` skill instead — don't reach for the harness by default.
+- **Read the reference before writing code.** Each capability has its own configuration, constraints, and gotchas — load the linked reference (e.g. [Code Mode](./references/CODE-MODE.md)) first.
+- **Install the capability's extra.** Importing `CodeMode` without `pydantic-ai-harness[codemode]` raises an `ImportError`; the Monty sandbox is an optional dependency.
+
+## Common Gotchas
+
+- **`native=True` tools bypass `CodeMode`.** Provider-native MCP servers and web search execute server-side, so `run_code` never sees them. Construct them with `native=False` to keep them local and wrappable.
+- **The Monty sandbox is a Python subset.** No class definitions, no third-party imports, and only a small stdlib allowlist — read [Code Mode](./references/CODE-MODE.md#sandbox-restrictions) before debugging generated code that fails to run.
+- **`CodeMode` needs its extra.** Install `pydantic-ai-harness[codemode]`, not the bare package.

--- a/plugins/pydantic-ai-harness/skills/pydantic-ai-harness/references/CODE-MODE.md
+++ b/plugins/pydantic-ai-harness/skills/pydantic-ai-harness/references/CODE-MODE.md
@@ -1,0 +1,176 @@
+# Code Mode
+
+Standard tool calling takes one model round-trip per tool call. `CodeMode` wraps eligible tools into a
+single `run_code` tool so the model can write Python that loops, branches, aggregates, and parallelizes tool work inside a sandbox.
+
+Use it when the agent needs to call several tools, transform intermediate results, run concurrent
+tool work with `asyncio.gather`, or anywhere a simple Python script is more reliable than the model alone, such as for mathematics.
+
+## Install
+
+Code Mode needs the Monty sandbox, pulled in by the `codemode` extra:
+
+```bash
+uv add "pydantic-ai-harness[codemode]"   # `code-mode` is also accepted as an alias
+```
+
+## Basic Pattern
+
+```python {test="skip"}
+from pydantic_ai import Agent
+
+from pydantic_ai_harness import CodeMode
+
+agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[CodeMode()])
+
+
+@agent.tool_plain
+def get_weather(city: str) -> dict:
+    return {'city': city, 'temp_f': 72, 'condition': 'sunny'}
+
+
+@agent.tool_plain
+def convert_temp(fahrenheit: float) -> float:
+    return round((fahrenheit - 32) * 5 / 9, 1)
+```
+
+The model could generate code like:
+
+```python {test="skip" lint="skip"}
+paris, tokyo = await asyncio.gather(
+    get_weather(city='Paris'),
+    get_weather(city='Tokyo'),
+)
+paris_c = await convert_temp(fahrenheit=paris['temp_f'])
+tokyo_c = await convert_temp(fahrenheit=tokyo['temp_f'])
+{'paris': paris_c, 'tokyo': tokyo_c}
+```
+
+This reduces four model round-trips to one.
+
+## Choose Which Tools Are Sandboxed
+
+The `tools` parameter controls which tools move behind `run_code`.
+
+```python
+from pydantic_ai_harness import CodeMode
+
+CodeMode(tools='all')
+CodeMode(tools=['search', 'fetch'])
+CodeMode(tools=lambda ctx, td: td.name != 'dangerous_tool')
+CodeMode(tools={'code_mode': True})
+```
+
+Metadata-based selection is useful when the project already groups tools into toolsets:
+
+```python {test="skip" lint="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.toolsets import FunctionToolset
+from pydantic_ai_harness import CodeMode
+
+search_tools = FunctionToolset(tools=[search, fetch]).with_metadata(code_mode=True)
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    toolsets=[search_tools],
+    capabilities=[CodeMode(tools={'code_mode': True})],
+)
+```
+
+Non-matching tools remain regular tool calls.
+
+## Return Values
+
+`run_code` captures the last expression automatically.
+
+| Scenario | Return |
+| --- | --- |
+| No print output | Last expression value |
+| With print output | `{"output": "<printed text>", "result": <last expression>}` |
+| Multimodal content | Returned natively for model processing |
+
+If the user expects a raw dict or list back, avoid unnecessary `print()` statements.
+
+## Retries
+
+```python
+from pydantic_ai_harness import CodeMode
+
+CodeMode(
+    tools='all',
+    max_retries=3,
+)
+```
+
+Use `max_retries` when sandbox execution errors are expected to be recoverable.
+If the generated code fails during sandbox execution, the error message is sent back to the model, and it is asked to redraft the code in light of that failure. This process is repeated up to `max_retries` times, or until the code executes successfully.
+
+## REPL State
+
+State persists between `run_code` calls during the same agent run. Imports, variables, and helper
+functions carry over until the run ends. Use `restart: true` in the tool call to reset state when the
+conversation has drifted or stale state is causing wrong behavior.
+
+## Sandbox Restrictions
+
+Code runs inside Monty, an implementation of Python which intentionally supports only a subset of features.
+
+Key restrictions:
+
+- No class definitions
+- No third-party imports
+- No `import *`
+- Only a small stdlib subset is allowed: `sys`, `typing`, `asyncio`, `math`, `json`, `re`, `datetime`, `os`, `pathlib`
+- No wall-clock or timing primitives: `asyncio.sleep`, `datetime.datetime.now()`, `datetime.date.today()`, and the `time` module are unavailable
+- Tools that need approval or deferred execution are excluded from the sandbox
+
+When a generated example keeps failing, check these restrictions before changing the rest of the agent.
+
+## API
+
+```python {test="skip" lint="skip"}
+CodeMode(
+    tools: ToolSelector = 'all',   # 'all', list[str], callable, or dict
+    max_retries: int = 3,          # retries on sandbox execution errors
+)
+```
+
+## Agent Specs
+
+When the user defines the agent in YAML or JSON, the loader needs to know how to build `CodeMode`:
+
+```yaml
+model: anthropic:claude-sonnet-4-6
+capabilities:
+  - CodeMode: {}
+```
+
+```python {test="skip"}
+from pydantic_ai import Agent
+
+from pydantic_ai_harness import CodeMode
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[CodeMode])
+```
+
+The same pattern applies when passing arguments:
+
+```yaml
+capabilities:
+  - CodeMode:
+      tools: ['search', 'fetch']
+      max_retries: 5
+```
+
+## Observability
+
+With Logfire or another OpenTelemetry backend, nested tool calls inside `run_code` produce child spans.
+That makes CodeMode much easier to debug than a plain blob of generated code.
+
+```python {test="skip" lint="skip"}
+for msg in result.all_messages():
+    for part in msg.parts:
+        if isinstance(part, ToolReturnPart) and part.tool_name == 'run_code':
+            tool_calls = part.metadata['tool_calls']    # dict[str, ToolCallPart]
+            tool_returns = part.metadata['tool_returns'] # dict[str, ToolReturnPart]
+```

--- a/scripts/check-skill-sync.sh
+++ b/scripts/check-skill-sync.sh
@@ -44,4 +44,8 @@ check_dir_sync \
     plugins/ai/skills/building-pydantic-ai-agents \
     skills/building-pydantic-ai-agents
 
+check_dir_sync \
+    plugins/pydantic-ai-harness/skills/pydantic-ai-harness \
+    skills/pydantic-ai-harness
+
 exit $exit_code

--- a/scripts/sync-from-upstream.sh
+++ b/scripts/sync-from-upstream.sh
@@ -69,6 +69,13 @@ sync_skill \
     "skills/building-pydantic-ai-agents" \
     "building-pydantic-ai-agents"
 
+sync_skill \
+    "pydantic/pydantic-ai-harness" \
+    "pydantic_ai_harness/.agents/skills/pydantic-ai-harness" \
+    "plugins/pydantic-ai-harness/skills/pydantic-ai-harness" \
+    "skills/pydantic-ai-harness" \
+    "pydantic-ai-harness"
+
 echo
 echo "Sync complete. Summary:"
 cat "$SUMMARY_FILE"

--- a/skills/pydantic-ai-harness/SKILL.md
+++ b/skills/pydantic-ai-harness/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: pydantic-ai-harness
+description: Extend Pydantic AI agents with batteries-included capabilities from pydantic-ai-harness — currently Code Mode, which collapses many tool calls into one sandboxed Python execution. Use when the user mentions pydantic-ai-harness, CodeMode, Monty, code mode, or tool sandboxing, when they want an agent to run agent-written Python, or when a Pydantic AI agent would benefit from orchestrating multiple tool calls in a single sandboxed script.
+license: MIT
+compatibility: Requires Python 3.10+ and pydantic-ai-slim>=1.95.1
+metadata:
+  version: "0.1.0"
+  author: pydantic
+---
+
+# Building with Pydantic AI Harness
+
+Pydantic AI Harness is the official capability library for Pydantic AI. Capabilities that need model or
+framework support — and those fundamental to every agent — live in core `pydantic-ai`; optional,
+batteries-included capabilities live here. Both are composed onto an agent through the same
+`capabilities=[...]` API.
+
+This skill covers the capabilities shipped by `pydantic-ai-harness`. For the core framework — agents,
+tools, structured output, hooks, and testing — use the `building-pydantic-ai-agents` skill instead.
+
+## When to Use This Skill
+
+Invoke this skill when:
+- The user mentions `pydantic-ai-harness`, `CodeMode`, code mode, or the Monty sandbox
+- An agent makes many sequential tool calls that could collapse into one sandboxed Python execution
+- The user wants the model to write Python that loops, branches, aggregates, or parallelizes tool calls with `asyncio.gather`
+- The user asks to sandbox or constrain the code an agent runs
+
+Do **not** use this skill for:
+- Core Pydantic AI usage — building agents, adding tools, structured output, streaming, or testing (use `building-pydantic-ai-agents`)
+- Capabilities that ship in core `pydantic-ai`, such as web search, tool search, and thinking
+- The Pydantic validation library on its own (`pydantic`/`BaseModel` without agents)
+
+## Supported Capabilities
+
+| Capability | Description | Reference |
+|---|---|---|
+| `CodeMode` | Wraps eligible tools into a single sandboxed `run_code` tool so the model orchestrates them in Python | [Code Mode](./references/CODE-MODE.md) |
+
+More capability areas are tracked in the
+[capability matrix](https://github.com/pydantic/pydantic-ai-harness#capability-matrix); as they stabilize,
+this skill grows to cover them.
+
+## Install
+
+```bash
+uv add pydantic-ai-harness
+```
+
+Each capability declares its own extra. Code Mode needs the Monty sandbox:
+
+```bash
+uv add "pydantic-ai-harness[codemode]"   # `code-mode` is also accepted as an alias
+```
+
+Requires Python 3.10+ and `pydantic-ai-slim>=1.95.1`.
+
+## Quick Start
+
+A harness capability is added to the agent like any other. Here `CodeMode` wraps an MCP server's tools into
+a single `run_code` tool that the model drives with Python.
+
+```python {test="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import MCP  # MCP ships in core pydantic-ai
+
+from pydantic_ai_harness import CodeMode
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    capabilities=[
+        # native=False routes the MCP tools through a local toolset so CodeMode can wrap them.
+        # Without it, providers with native MCP run the tools server-side and bypass the sandbox.
+        MCP('https://hn.caseyjhand.com/mcp', native=False),
+        CodeMode(),
+    ],
+)
+
+result = agent.run_sync(
+    'Across the top and best Hacker News feeds, find the most-discussed story with at '
+    'least 100 points and summarize its comment thread in one paragraph.'
+)
+print(result.output)
+#> The most-discussed story clearing 100 points is ...
+```
+
+Instead of one model round-trip per tool call, the model writes a single Python script that fetches both
+feeds with `asyncio.gather`, dedupes and ranks them in plain Python, and pulls the winning thread —
+collapsing many calls into one `run_code`.
+
+## Key Practices
+
+- **Confirm a harness capability is actually needed.** If core Pydantic AI tools and capabilities are enough, use the `building-pydantic-ai-agents` skill instead — don't reach for the harness by default.
+- **Read the reference before writing code.** Each capability has its own configuration, constraints, and gotchas — load the linked reference (e.g. [Code Mode](./references/CODE-MODE.md)) first.
+- **Install the capability's extra.** Importing `CodeMode` without `pydantic-ai-harness[codemode]` raises an `ImportError`; the Monty sandbox is an optional dependency.
+
+## Common Gotchas
+
+- **`native=True` tools bypass `CodeMode`.** Provider-native MCP servers and web search execute server-side, so `run_code` never sees them. Construct them with `native=False` to keep them local and wrappable.
+- **The Monty sandbox is a Python subset.** No class definitions, no third-party imports, and only a small stdlib allowlist — read [Code Mode](./references/CODE-MODE.md#sandbox-restrictions) before debugging generated code that fails to run.
+- **`CodeMode` needs its extra.** Install `pydantic-ai-harness[codemode]`, not the bare package.

--- a/skills/pydantic-ai-harness/references/CODE-MODE.md
+++ b/skills/pydantic-ai-harness/references/CODE-MODE.md
@@ -1,0 +1,176 @@
+# Code Mode
+
+Standard tool calling takes one model round-trip per tool call. `CodeMode` wraps eligible tools into a
+single `run_code` tool so the model can write Python that loops, branches, aggregates, and parallelizes tool work inside a sandbox.
+
+Use it when the agent needs to call several tools, transform intermediate results, run concurrent
+tool work with `asyncio.gather`, or anywhere a simple Python script is more reliable than the model alone, such as for mathematics.
+
+## Install
+
+Code Mode needs the Monty sandbox, pulled in by the `codemode` extra:
+
+```bash
+uv add "pydantic-ai-harness[codemode]"   # `code-mode` is also accepted as an alias
+```
+
+## Basic Pattern
+
+```python {test="skip"}
+from pydantic_ai import Agent
+
+from pydantic_ai_harness import CodeMode
+
+agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[CodeMode()])
+
+
+@agent.tool_plain
+def get_weather(city: str) -> dict:
+    return {'city': city, 'temp_f': 72, 'condition': 'sunny'}
+
+
+@agent.tool_plain
+def convert_temp(fahrenheit: float) -> float:
+    return round((fahrenheit - 32) * 5 / 9, 1)
+```
+
+The model could generate code like:
+
+```python {test="skip" lint="skip"}
+paris, tokyo = await asyncio.gather(
+    get_weather(city='Paris'),
+    get_weather(city='Tokyo'),
+)
+paris_c = await convert_temp(fahrenheit=paris['temp_f'])
+tokyo_c = await convert_temp(fahrenheit=tokyo['temp_f'])
+{'paris': paris_c, 'tokyo': tokyo_c}
+```
+
+This reduces four model round-trips to one.
+
+## Choose Which Tools Are Sandboxed
+
+The `tools` parameter controls which tools move behind `run_code`.
+
+```python
+from pydantic_ai_harness import CodeMode
+
+CodeMode(tools='all')
+CodeMode(tools=['search', 'fetch'])
+CodeMode(tools=lambda ctx, td: td.name != 'dangerous_tool')
+CodeMode(tools={'code_mode': True})
+```
+
+Metadata-based selection is useful when the project already groups tools into toolsets:
+
+```python {test="skip" lint="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.toolsets import FunctionToolset
+from pydantic_ai_harness import CodeMode
+
+search_tools = FunctionToolset(tools=[search, fetch]).with_metadata(code_mode=True)
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    toolsets=[search_tools],
+    capabilities=[CodeMode(tools={'code_mode': True})],
+)
+```
+
+Non-matching tools remain regular tool calls.
+
+## Return Values
+
+`run_code` captures the last expression automatically.
+
+| Scenario | Return |
+| --- | --- |
+| No print output | Last expression value |
+| With print output | `{"output": "<printed text>", "result": <last expression>}` |
+| Multimodal content | Returned natively for model processing |
+
+If the user expects a raw dict or list back, avoid unnecessary `print()` statements.
+
+## Retries
+
+```python
+from pydantic_ai_harness import CodeMode
+
+CodeMode(
+    tools='all',
+    max_retries=3,
+)
+```
+
+Use `max_retries` when sandbox execution errors are expected to be recoverable.
+If the generated code fails during sandbox execution, the error message is sent back to the model, and it is asked to redraft the code in light of that failure. This process is repeated up to `max_retries` times, or until the code executes successfully.
+
+## REPL State
+
+State persists between `run_code` calls during the same agent run. Imports, variables, and helper
+functions carry over until the run ends. Use `restart: true` in the tool call to reset state when the
+conversation has drifted or stale state is causing wrong behavior.
+
+## Sandbox Restrictions
+
+Code runs inside Monty, an implementation of Python which intentionally supports only a subset of features.
+
+Key restrictions:
+
+- No class definitions
+- No third-party imports
+- No `import *`
+- Only a small stdlib subset is allowed: `sys`, `typing`, `asyncio`, `math`, `json`, `re`, `datetime`, `os`, `pathlib`
+- No wall-clock or timing primitives: `asyncio.sleep`, `datetime.datetime.now()`, `datetime.date.today()`, and the `time` module are unavailable
+- Tools that need approval or deferred execution are excluded from the sandbox
+
+When a generated example keeps failing, check these restrictions before changing the rest of the agent.
+
+## API
+
+```python {test="skip" lint="skip"}
+CodeMode(
+    tools: ToolSelector = 'all',   # 'all', list[str], callable, or dict
+    max_retries: int = 3,          # retries on sandbox execution errors
+)
+```
+
+## Agent Specs
+
+When the user defines the agent in YAML or JSON, the loader needs to know how to build `CodeMode`:
+
+```yaml
+model: anthropic:claude-sonnet-4-6
+capabilities:
+  - CodeMode: {}
+```
+
+```python {test="skip"}
+from pydantic_ai import Agent
+
+from pydantic_ai_harness import CodeMode
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[CodeMode])
+```
+
+The same pattern applies when passing arguments:
+
+```yaml
+capabilities:
+  - CodeMode:
+      tools: ['search', 'fetch']
+      max_retries: 5
+```
+
+## Observability
+
+With Logfire or another OpenTelemetry backend, nested tool calls inside `run_code` produce child spans.
+That makes CodeMode much easier to debug than a plain blob of generated code.
+
+```python {test="skip" lint="skip"}
+for msg in result.all_messages():
+    for part in msg.parts:
+        if isinstance(part, ToolReturnPart) and part.tool_name == 'run_code':
+            tool_calls = part.metadata['tool_calls']    # dict[str, ToolCallPart]
+            tool_returns = part.metadata['tool_returns'] # dict[str, ToolReturnPart]
+```


### PR DESCRIPTION
Wires [`pydantic/pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness) into the aggregator as a synced skill and a marketplace plugin.

## Sync mechanism
- `scripts/sync-from-upstream.sh`: new `sync_skill` entry mirroring `pydantic_ai_harness/.agents/skills/pydantic-ai-harness/` to both the plugin dir and the standalone `skills/` dir. The daily workflow picks this up automatically going forward.
- `scripts/check-skill-sync.sh`: enforces the plugin/standalone byte-identical invariant for the new skill (passes locally).
- Skill content was produced by **running the sync script** (upstream `@ad1a201`), not hand-authored — so it matches upstream exactly and the next sync is a no-op until upstream changes.

## Marketplace plugin
- New `pydantic-ai-harness` entry in `.claude-plugin/marketplace.json`.
- `plugins/pydantic-ai-harness/` scaffolding: `plugin.json` + `README.md`.
- Packaged as its own plugin (separate upstream repo, own MIT license + version) rather than folded into `ai`.

## Docs
- README.md plugins table, install list, and standalone-skills table.
- CONTRIBUTING.md upstream-source table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)