### PR TITLE
logfire-exporter: stop broken python3 shims from stalling Codex hooks

### DIFF
--- a/plugins/logfire-exporter/README.md
+++ b/plugins/logfire-exporter/README.md
@@ -127,6 +127,25 @@ Install `logfire-exporter` when you want telemetry about Codex itself. Install `
 help instrument applications, query existing Logfire data, or open Logfire UI views.
 The two plugins can be enabled together.
 
+## Python Interpreter Selection
+
+The hooks run `scripts/run_codex_logfire_hook.sh`, which picks a working Python 3 interpreter rather
+than trusting a bare `python3`: version-manager shims (notably pyenv's) can hang instead of failing
+when their backing installation is broken, which previously made every hook run to its timeout and
+stalled the conversation. The wrapper probes candidates (`python3` on `PATH`, then common system
+locations) with a 2-second watchdog, caches the first one that answers under
+`${XDG_STATE_HOME:-~/.local/state}/logfire-exporter/python_interpreter`, and skips exporting
+entirely when none works.
+
+To pin a specific interpreter, set `CODEX_LOGFIRE_PYTHON` (in the hook environment or in the
+`config.env` file):
+
+```dotenv
+CODEX_LOGFIRE_PYTHON=/opt/homebrew/bin/python3.13
+```
+
+A pinned interpreter is used as-is, with no probe.
+
 ## Troubleshooting
 
 Debug logs are written under:
@@ -140,6 +159,13 @@ If no spans or plugin logs appear after a completed Codex turn, check the Codex 
 ```bash
 rg -n "logfire-exporter|failed to load plugin" ~/.codex/log/codex-tui.log
 ```
+
+If hooks report timeouts (a "Hooks summary" with `hook timed out` errors) or chats feel slow after
+enabling the plugin, your `python3` is probably a broken version-manager shim. Fix the shim (for
+pyenv: `pyenv rehash`, or reinstall the selected version) or pin a known-good interpreter with
+`CODEX_LOGFIRE_PYTHON` as described above. Set `CODEX_LOGFIRE_DEBUG=1` in the hook environment to
+see the interpreter selection on stderr, and delete the cached choice at
+`${XDG_STATE_HOME:-~/.local/state}/logfire-exporter/python_interpreter` to force a rescan.
 
 ## Test
 

--- a/plugins/logfire-exporter/README.md
+++ b/plugins/logfire-exporter/README.md
@@ -129,22 +129,32 @@ The two plugins can be enabled together.
 
 ## Python Interpreter Selection
 
-The hooks run `scripts/run_codex_logfire_hook.sh`, which picks a working Python 3 interpreter rather
-than trusting a bare `python3`: version-manager shims (notably pyenv's) can hang instead of failing
-when their backing installation is broken, which previously made every hook run to its timeout and
-stalled the conversation. The wrapper probes candidates (`python3` on `PATH`, then common system
-locations) with a 2-second watchdog, caches the first one that answers under
-`${XDG_STATE_HOME:-~/.local/state}/logfire-exporter/python_interpreter`, and skips exporting
-entirely when none works.
+On macOS and Linux, the hooks run `scripts/run_codex_logfire_hook.sh`. Before looking up Python, the
+wrapper changes to the exporter's accessible, absolute script directory. This avoids
+[pyenv #3513](https://github.com/pyenv/pyenv/issues/3513), in which pyenv's version-file search can
+loop forever when a launcher supplies a relative `PWD` such as `.`. The original project cwd still
+reaches the Python hook in the hook's stdin JSON.
 
-To pin a specific interpreter, set `CODEX_LOGFIRE_PYTHON` (in the hook environment or in the
-`config.env` file):
+The POSIX wrapper then probes candidates (`python3` on `PATH`, followed by common system locations)
+with a 2-second watchdog. It snapshots and terminates the entire probe process tree on timeout,
+caches the first interpreter that answers under
+`${XDG_STATE_HOME:-~/.local/state}/logfire-exporter/python_interpreter`, and skips exporting
+entirely when none works. These checks also contain unrelated broken or hanging interpreter shims.
+
+To pin a specific interpreter on POSIX, set `CODEX_LOGFIRE_PYTHON` in the hook environment or in the
+`config.env` file:
 
 ```dotenv
 CODEX_LOGFIRE_PYTHON=/opt/homebrew/bin/python3.13
 ```
 
 A pinned interpreter is used as-is, with no probe.
+
+On Windows, the hooks use `scripts/run_codex_logfire_hook.cmd` and retain direct interpreter
+launching. The launcher uses `CODEX_LOGFIRE_PYTHON` when it is present in the hook environment, then
+tries `python3`, `py -3`, and `python`, and always fails open. It does not read the interpreter choice
+from `config.env`, probe candidates, or cache a selection; the configured Codex hook timeout remains
+the timeout protection on Windows.
 
 ## Troubleshooting
 
@@ -160,12 +170,21 @@ If no spans or plugin logs appear after a completed Codex turn, check the Codex 
 rg -n "logfire-exporter|failed to load plugin" ~/.codex/log/codex-tui.log
 ```
 
-If hooks report timeouts (a "Hooks summary" with `hook timed out` errors) or chats feel slow after
-enabling the plugin, your `python3` is probably a broken version-manager shim. Fix the shim (for
-pyenv: `pyenv rehash`, or reinstall the selected version) or pin a known-good interpreter with
-`CODEX_LOGFIRE_PYTHON` as described above. Set `CODEX_LOGFIRE_DEBUG=1` in the hook environment to
-see the interpreter selection on stderr, and delete the cached choice at
-`${XDG_STATE_HOME:-~/.local/state}/logfire-exporter/python_interpreter` to force a rescan.
+If POSIX hooks report timeouts (a "Hooks summary" with `hook timed out` errors) or chats feel slow
+after enabling the plugin, distinguish these cases:
+
+- A relative `PWD` such as `.` can trigger the infinite loop in
+  [pyenv #3513](https://github.com/pyenv/pyenv/issues/3513). The wrapper's absolute working-directory
+  normalization contains this case. `pyenv rehash` or reinstalling the selected Python does not fix
+  that relative-directory bug; pyenv and the launcher's `PWD` handling remain the upstream fixes.
+- A shim can be broken for an unrelated reason, such as pointing to a missing interpreter. Repair
+  the version-manager installation in that case, or pin a known-good absolute interpreter with
+  `CODEX_LOGFIRE_PYTHON` as described above.
+
+Set `CODEX_LOGFIRE_DEBUG=1` in the POSIX hook environment to see interpreter selection on stderr.
+Delete `${XDG_STATE_HOME:-~/.local/state}/logfire-exporter/python_interpreter` to force the POSIX
+wrapper to rescan. Windows does not create or use that cache; set `CODEX_LOGFIRE_PYTHON` in the
+Windows hook environment if its default interpreter command is unusable.
 
 ## Test
 

--- a/plugins/logfire-exporter/hooks/hooks.json
+++ b/plugins/logfire-exporter/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/codex_logfire_hook.py\"",
+            "command": "sh \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/run_codex_logfire_hook.sh\"",
             "timeout": 10,
             "statusMessage": "Preparing Logfire telemetry"
           }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/codex_logfire_hook.py\"",
+            "command": "sh \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/run_codex_logfire_hook.sh\"",
             "timeout": 10
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/codex_logfire_hook.py\"",
+            "command": "sh \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/run_codex_logfire_hook.sh\"",
             "timeout": 10
           }
         ]
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/codex_logfire_hook.py\"",
+            "command": "sh \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/run_codex_logfire_hook.sh\"",
             "timeout": 30
           }
         ]

--- a/plugins/logfire-exporter/hooks/hooks.json
+++ b/plugins/logfire-exporter/hooks/hooks.json
@@ -7,6 +7,7 @@
           {
             "type": "command",
             "command": "sh \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/run_codex_logfire_hook.sh\"",
+            "commandWindows": "call \"%PLUGIN_ROOT%\\scripts\\run_codex_logfire_hook.cmd\"",
             "timeout": 10,
             "statusMessage": "Preparing Logfire telemetry"
           }
@@ -19,6 +20,7 @@
           {
             "type": "command",
             "command": "sh \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/run_codex_logfire_hook.sh\"",
+            "commandWindows": "call \"%PLUGIN_ROOT%\\scripts\\run_codex_logfire_hook.cmd\"",
             "timeout": 10
           }
         ]
@@ -31,6 +33,7 @@
           {
             "type": "command",
             "command": "sh \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/run_codex_logfire_hook.sh\"",
+            "commandWindows": "call \"%PLUGIN_ROOT%\\scripts\\run_codex_logfire_hook.cmd\"",
             "timeout": 10
           }
         ]
@@ -42,6 +45,7 @@
           {
             "type": "command",
             "command": "sh \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/run_codex_logfire_hook.sh\"",
+            "commandWindows": "call \"%PLUGIN_ROOT%\\scripts\\run_codex_logfire_hook.cmd\"",
             "timeout": 30
           }
         ]

--- a/plugins/logfire-exporter/scripts/run_codex_logfire_hook.cmd
+++ b/plugins/logfire-exporter/scripts/run_codex_logfire_hook.cmd
@@ -1,0 +1,28 @@
+@echo off
+setlocal
+
+rem Windows keeps the original direct-Python behavior. Interpreter failures
+rem fail open because telemetry must never block or break a Codex turn.
+if defined CODEX_LOGFIRE_PYTHON (
+    "%CODEX_LOGFIRE_PYTHON%" "%~dp0codex_logfire_hook.py"
+    exit /b 0
+)
+
+where python3.exe >nul 2>nul
+if not errorlevel 1 (
+    python3 "%~dp0codex_logfire_hook.py"
+    exit /b 0
+)
+
+where py.exe >nul 2>nul
+if not errorlevel 1 (
+    py -3 "%~dp0codex_logfire_hook.py"
+    exit /b 0
+)
+
+where python.exe >nul 2>nul
+if not errorlevel 1 (
+    python "%~dp0codex_logfire_hook.py"
+)
+
+exit /b 0

--- a/plugins/logfire-exporter/scripts/run_codex_logfire_hook.cmd
+++ b/plugins/logfire-exporter/scripts/run_codex_logfire_hook.cmd
@@ -11,13 +11,13 @@ if defined CODEX_LOGFIRE_PYTHON (
 where python3.exe >nul 2>nul
 if not errorlevel 1 (
     python3 "%~dp0codex_logfire_hook.py"
-    exit /b 0
+    if not errorlevel 1 exit /b 0
 )
 
 where py.exe >nul 2>nul
 if not errorlevel 1 (
     py -3 "%~dp0codex_logfire_hook.py"
-    exit /b 0
+    if not errorlevel 1 exit /b 0
 )
 
 where python.exe >nul 2>nul

--- a/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
+++ b/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
@@ -69,7 +69,19 @@ probe() {
             sleep 0.1 2>/dev/null || { sleep 1; ticks=$((ticks + 9)); }
             ticks=$((ticks + 1))
         done
+        # A hanging shim usually blocks on a child it spawned; sweep that
+        # child too so it is not orphaned to run to completion (one leaked
+        # process per hook run). Snapshot the children BEFORE killing the
+        # parent: killing them first can let the parent finish cleanly and
+        # the probe would then count as a success, selecting the hung shim.
+        # (setsid + a process-group kill would be more thorough, but setsid
+        # does not exist on macOS, where this failure mode is most common.)
+        probe_children=$(pgrep -P "$probe_pid" 2>/dev/null)
         kill -9 "$probe_pid" 2>/dev/null
+        if [ -n "$probe_children" ]; then
+            # shellcheck disable=SC2086 # word-splitting the PID list is intended
+            kill -9 $probe_children 2>/dev/null
+        fi
     ) &
     watchdog_pid=$!
     wait "$probe_pid" 2>/dev/null

--- a/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
+++ b/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
@@ -55,7 +55,13 @@ load_python_from_config() {
     if [ -n "${CODEX_LOGFIRE_CONFIG_FILE:-}" ]; then
         config_file=$CODEX_LOGFIRE_CONFIG_FILE
     else
-        config_home=${XDG_CONFIG_HOME:-$HOME/.config}
+        if [ -n "${XDG_CONFIG_HOME:-}" ]; then
+            config_home=$XDG_CONFIG_HOME
+        elif [ -n "${HOME:-}" ]; then
+            config_home="$HOME/.config"
+        else
+            return 1
+        fi
         config_file="$config_home/logfire-exporter/config.env"
         if [ ! -f "$config_file" ]; then
             for legacy_dir in codex-logfire-exporter codex-logfire-plugin; do

--- a/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
+++ b/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
@@ -43,7 +43,21 @@ debug() {
 # The hook script itself loads config.env, but the interpreter choice is
 # needed before any Python runs, so read this one key here too.
 load_python_from_config() {
-    config_file="${CODEX_LOGFIRE_CONFIG_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/logfire-exporter/config.env}"
+    if [ -n "${CODEX_LOGFIRE_CONFIG_FILE:-}" ]; then
+        config_file=$CODEX_LOGFIRE_CONFIG_FILE
+    else
+        config_home=${XDG_CONFIG_HOME:-$HOME/.config}
+        config_file="$config_home/logfire-exporter/config.env"
+        if [ ! -f "$config_file" ]; then
+            for legacy_dir in codex-logfire-exporter codex-logfire-plugin; do
+                legacy_file="$config_home/$legacy_dir/config.env"
+                if [ -f "$legacy_file" ]; then
+                    config_file=$legacy_file
+                    break
+                fi
+            done
+        fi
+    fi
     [ -f "$config_file" ] || return 1
     # Accept the same shapes the hook's own config parser does: optional
     # whitespace around the key and '=', and whitespace-padded values.

--- a/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
+++ b/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
@@ -58,6 +58,15 @@ load_python_from_config() {
     return 0
 }
 
+# Print every descendant of a process, deepest first. macOS has pgrep but no
+# setsid, so the watchdog snapshots the tree explicitly before killing it.
+collect_descendants() {
+    for child_pid in $(pgrep -P "$1" 2>/dev/null); do
+        collect_descendants "$child_pid"
+        printf '%s\n' "$child_pid"
+    done
+}
+
 # probe <interpreter>: true when the interpreter starts, is Python 3, and
 # exits within the watchdog window. Stdin is redirected away so a probe can
 # never consume the hook payload.
@@ -74,18 +83,17 @@ probe() {
             sleep 0.1 2>/dev/null || { sleep 1; ticks=$((ticks + 9)); }
             ticks=$((ticks + 1))
         done
-        # A hanging shim usually blocks on a child it spawned; sweep that
-        # child too so it is not orphaned to run to completion (one leaked
-        # process per hook run). Snapshot the children BEFORE killing the
-        # parent: killing them first can let the parent finish cleanly and
-        # the probe would then count as a success, selecting the hung shim.
+        # A hanging shim can block on a chain of child processes. Snapshot the
+        # complete descendant tree BEFORE killing the parent so none are
+        # orphaned to keep running. Killing descendants first can let the
+        # parent finish cleanly and make the probe select the hung shim.
         # (setsid + a process-group kill would be more thorough, but setsid
         # does not exist on macOS, where this failure mode is most common.)
-        probe_children=$(pgrep -P "$probe_pid" 2>/dev/null)
+        probe_descendants=$(collect_descendants "$probe_pid")
         kill -9 "$probe_pid" 2>/dev/null
-        if [ -n "$probe_children" ]; then
+        if [ -n "$probe_descendants" ]; then
             # shellcheck disable=SC2086 # word-splitting the PID list is intended
-            kill -9 $probe_children 2>/dev/null
+            kill -9 $probe_descendants 2>/dev/null
         fi
     ) &
     watchdog_pid=$!

--- a/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
+++ b/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 # Runs codex_logfire_hook.py with a Python interpreter that is known to work.
 #
-# Invoking a bare `python3` is not reliable: version-manager shims (notably
-# pyenv's) can hang instead of failing when their backing installation is
-# broken, and Codex then blocks on every hook until its timeout, grinding the
-# chat to a crawl. This wrapper probes interpreter candidates with a short
-# watchdog, caches the first one that answers, and fails open (exit 0) when
-# none does, so a broken Python setup degrades to "no telemetry" rather than
-# "stalled chats".
+# Invoking a bare `python3` is not reliable: version-manager shims can hang
+# because their backing installation is broken, while pyenv can also loop
+# forever when PWD is relative (https://github.com/pyenv/pyenv/issues/3513).
+# Codex then blocks on every hook until its timeout, grinding the chat to a
+# crawl. This wrapper normalizes the working directory, probes interpreter
+# candidates with a short watchdog, caches the first one that answers, and
+# fails open (exit 0) when none does. A broken Python setup therefore degrades
+# to "no telemetry" rather than "stalled chats".
 #
 # Configuration:
 #   CODEX_LOGFIRE_PYTHON     absolute path to the interpreter to use; trusted
@@ -23,9 +24,10 @@ set -u
 SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
 HOOK_SCRIPT="$SCRIPT_DIR/codex_logfire_hook.py"
 
-# Codex can launch hooks with a relative PWD (for example, PWD=.). Move to a
-# known absolute, accessible directory before invoking any interpreter shim.
-# The project cwd is carried in the hook's stdin payload, not process state.
+# Codex can launch hooks with a relative PWD (for example, PWD=.), triggering
+# pyenv #3513. Move to a known absolute, accessible directory before invoking
+# any interpreter shim. The project cwd is carried in the hook's stdin payload,
+# not process state.
 CDPATH='' cd -- "$SCRIPT_DIR" || exit 0
 
 STATE_DIR="${CODEX_LOGFIRE_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/logfire-exporter}"

--- a/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
+++ b/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
@@ -20,8 +20,13 @@
 
 set -u
 
-SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
 HOOK_SCRIPT="$SCRIPT_DIR/codex_logfire_hook.py"
+
+# Codex can launch hooks with a relative PWD (for example, PWD=.). Move to a
+# known absolute, accessible directory before invoking any interpreter shim.
+# The project cwd is carried in the hook's stdin payload, not process state.
+CDPATH='' cd -- "$SCRIPT_DIR" || exit 0
 
 STATE_DIR="${CODEX_LOGFIRE_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/logfire-exporter}"
 CACHE_FILE="$STATE_DIR/python_interpreter"

--- a/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
+++ b/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+# Runs codex_logfire_hook.py with a Python interpreter that is known to work.
+#
+# Invoking a bare `python3` is not reliable: version-manager shims (notably
+# pyenv's) can hang instead of failing when their backing installation is
+# broken, and Codex then blocks on every hook until its timeout, grinding the
+# chat to a crawl. This wrapper probes interpreter candidates with a short
+# watchdog, caches the first one that answers, and fails open (exit 0) when
+# none does, so a broken Python setup degrades to "no telemetry" rather than
+# "stalled chats".
+#
+# Configuration:
+#   CODEX_LOGFIRE_PYTHON     absolute path to the interpreter to use; trusted
+#                            as-is (no probe). May also be set in the exporter
+#                            config.env file.
+#   CODEX_LOGFIRE_STATE_DIR  overrides where the interpreter choice is cached
+#                            (same variable the hook itself uses for state).
+#   CODEX_LOGFIRE_DEBUG      when non-empty, selection details are written to
+#                            stderr.
+
+set -u
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+HOOK_SCRIPT="$SCRIPT_DIR/codex_logfire_hook.py"
+
+STATE_DIR="${CODEX_LOGFIRE_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/logfire-exporter}"
+CACHE_FILE="$STATE_DIR/python_interpreter"
+PROBE_TIMEOUT_TICKS=20 # x 0.1s = 2 seconds
+
+debug() {
+    if [ -n "${CODEX_LOGFIRE_DEBUG:-}" ]; then
+        printf 'run_codex_logfire_hook: %s\n' "$1" >&2
+    fi
+}
+
+# The hook script itself loads config.env, but the interpreter choice is
+# needed before any Python runs, so read this one key here too.
+load_python_from_config() {
+    config_file="${CODEX_LOGFIRE_CONFIG_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/logfire-exporter/config.env}"
+    [ -f "$config_file" ] || return 1
+    line=$(grep '^CODEX_LOGFIRE_PYTHON=' "$config_file" 2>/dev/null | tail -n 1) || return 1
+    [ -n "$line" ] || return 1
+    value=${line#CODEX_LOGFIRE_PYTHON=}
+    # Strip one layer of surrounding quotes, matching the hook's env parsing.
+    case $value in
+        \"*\") value=${value#\"}; value=${value%\"} ;;
+        \'*\') value=${value#\'}; value=${value%\'} ;;
+    esac
+    [ -n "$value" ] || return 1
+    CODEX_LOGFIRE_PYTHON=$value
+    return 0
+}
+
+# probe <interpreter>: true when the interpreter starts, is Python 3, and
+# exits within the watchdog window. Stdin is redirected away so a probe can
+# never consume the hook payload.
+probe() {
+    "$1" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)' </dev/null >/dev/null 2>&1 &
+    probe_pid=$!
+    (
+        ticks=0
+        while [ "$ticks" -lt "$PROBE_TIMEOUT_TICKS" ]; do
+            kill -0 "$probe_pid" 2>/dev/null || exit 0
+            # Fractional sleep is not POSIX; degrade to whole seconds where
+            # unsupported (the hook-level timeout still bounds the worst case).
+            sleep 0.1 2>/dev/null || sleep 1
+            ticks=$((ticks + 1))
+        done
+        kill -9 "$probe_pid" 2>/dev/null
+    ) &
+    watchdog_pid=$!
+    wait "$probe_pid" 2>/dev/null
+    probe_status=$?
+    kill "$watchdog_pid" 2>/dev/null
+    wait "$watchdog_pid" 2>/dev/null
+    [ "$probe_status" -eq 0 ]
+}
+
+run_with() {
+    exec "$1" "$HOOK_SCRIPT"
+}
+
+if [ -z "${CODEX_LOGFIRE_PYTHON:-}" ]; then
+    load_python_from_config || true
+fi
+
+if [ -n "${CODEX_LOGFIRE_PYTHON:-}" ]; then
+    debug "using CODEX_LOGFIRE_PYTHON=$CODEX_LOGFIRE_PYTHON"
+    run_with "$CODEX_LOGFIRE_PYTHON"
+fi
+
+# A previously cached interpreter is still probed (cheap when healthy) so a
+# cache pointing at a since-broken shim falls through to a fresh scan instead
+# of hanging.
+if [ -f "$CACHE_FILE" ]; then
+    cached=$(cat "$CACHE_FILE" 2>/dev/null || printf '')
+    if [ -n "$cached" ] && [ -x "$cached" ] && probe "$cached"; then
+        debug "using cached interpreter $cached"
+        run_with "$cached"
+    fi
+    debug "cached interpreter unusable, rescanning"
+fi
+
+for candidate in python3 /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3 python; do
+    resolved=$(command -v "$candidate" 2>/dev/null) || continue
+    if probe "$resolved"; then
+        debug "selected $resolved"
+        mkdir -p "$STATE_DIR" 2>/dev/null || true
+        printf '%s\n' "$resolved" > "$CACHE_FILE" 2>/dev/null || true
+        run_with "$resolved"
+    fi
+    debug "candidate $resolved failed probe"
+done
+
+# Fail open: exporting telemetry is never worth breaking the conversation.
+debug "no working Python 3 interpreter found; skipping export"
+exit 0

--- a/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
+++ b/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
@@ -39,6 +39,9 @@ fi
 STATE_DIR="${CODEX_LOGFIRE_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/logfire-exporter}"
 CACHE_FILE="$STATE_DIR/python_interpreter"
 PROBE_TIMEOUT_TICKS=20 # x 0.1s = 2 seconds
+MAX_PROBES=3           # keep total automatic selection below 10s hook timeouts
+probe_count=0
+seen_candidates=''
 
 debug() {
     if [ -n "${CODEX_LOGFIRE_DEBUG:-}" ]; then
@@ -126,6 +129,26 @@ probe() {
     [ "$probe_status" -eq 0 ]
 }
 
+probe_within_budget() {
+    [ "$probe_count" -lt "$MAX_PROBES" ] || return 1
+    probe_count=$((probe_count + 1))
+    probe "$1"
+}
+
+candidate_seen() {
+    [ -n "$seen_candidates" ] &&
+        printf '%s\n' "$seen_candidates" | grep -F -x -- "$1" >/dev/null 2>&1
+}
+
+remember_candidate() {
+    if [ -n "$seen_candidates" ]; then
+        seen_candidates="$seen_candidates
+$1"
+    else
+        seen_candidates=$1
+    fi
+}
+
 run_with() {
     exec "$1" "$HOOK_SCRIPT"
 }
@@ -144,16 +167,28 @@ fi
 # of hanging.
 if [ -f "$CACHE_FILE" ]; then
     cached=$(cat "$CACHE_FILE" 2>/dev/null || printf '')
-    if [ -n "$cached" ] && [ -x "$cached" ] && probe "$cached"; then
-        debug "using cached interpreter $cached"
-        run_with "$cached"
+    if [ -n "$cached" ] && [ -x "$cached" ]; then
+        remember_candidate "$cached"
+        if probe_within_budget "$cached"; then
+            debug "using cached interpreter $cached"
+            run_with "$cached"
+        fi
     fi
     debug "cached interpreter unusable, rescanning"
 fi
 
 for candidate in python3 /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3 python; do
     resolved=$(command -v "$candidate" 2>/dev/null) || continue
-    if probe "$resolved"; then
+    if candidate_seen "$resolved"; then
+        debug "skipping duplicate candidate $resolved"
+        continue
+    fi
+    if [ "$probe_count" -ge "$MAX_PROBES" ]; then
+        debug "probe budget exhausted; skipping remaining candidates"
+        break
+    fi
+    remember_candidate "$resolved"
+    if probe_within_budget "$resolved"; then
         debug "selected $resolved"
         mkdir -p "$STATE_DIR" 2>/dev/null || true
         printf '%s\n' "$resolved" > "$CACHE_FILE" 2>/dev/null || true

--- a/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
+++ b/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
@@ -38,9 +38,11 @@ debug() {
 load_python_from_config() {
     config_file="${CODEX_LOGFIRE_CONFIG_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/logfire-exporter/config.env}"
     [ -f "$config_file" ] || return 1
-    line=$(grep '^CODEX_LOGFIRE_PYTHON=' "$config_file" 2>/dev/null | tail -n 1) || return 1
+    # Accept the same shapes the hook's own config parser does: optional
+    # whitespace around the key and '=', and whitespace-padded values.
+    line=$(grep -E '^[[:space:]]*CODEX_LOGFIRE_PYTHON[[:space:]]*=' "$config_file" 2>/dev/null | tail -n 1) || return 1
     [ -n "$line" ] || return 1
-    value=${line#CODEX_LOGFIRE_PYTHON=}
+    value=$(printf '%s' "${line#*=}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
     # Strip one layer of surrounding quotes, matching the hook's env parsing.
     case $value in
         \"*\") value=${value#\"}; value=${value%\"} ;;
@@ -62,8 +64,9 @@ probe() {
         while [ "$ticks" -lt "$PROBE_TIMEOUT_TICKS" ]; do
             kill -0 "$probe_pid" 2>/dev/null || exit 0
             # Fractional sleep is not POSIX; degrade to whole seconds where
-            # unsupported (the hook-level timeout still bounds the worst case).
-            sleep 0.1 2>/dev/null || sleep 1
+            # unsupported, consuming ten ticks per second so the total
+            # watchdog window stays ~2s either way.
+            sleep 0.1 2>/dev/null || { sleep 1; ticks=$((ticks + 9)); }
             ticks=$((ticks + 1))
         done
         kill -9 "$probe_pid" 2>/dev/null

--- a/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
+++ b/plugins/logfire-exporter/scripts/run_codex_logfire_hook.sh
@@ -30,6 +30,12 @@ HOOK_SCRIPT="$SCRIPT_DIR/codex_logfire_hook.py"
 # not process state.
 CDPATH='' cd -- "$SCRIPT_DIR" || exit 0
 
+if [ -z "${CODEX_LOGFIRE_STATE_DIR:-}" ] &&
+    [ -z "${XDG_STATE_HOME:-}" ] &&
+    [ -z "${HOME:-}" ]; then
+    exit 0
+fi
+
 STATE_DIR="${CODEX_LOGFIRE_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/logfire-exporter}"
 CACHE_FILE="$STATE_DIR/python_interpreter"
 PROBE_TIMEOUT_TICKS=20 # x 0.1s = 2 seconds

--- a/plugins/logfire-exporter/tests/test_hooks_config.py
+++ b/plugins/logfire-exporter/tests/test_hooks_config.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import unittest
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOKS_PATH = ROOT / "hooks" / "hooks.json"
+WINDOWS_LAUNCHER_PATH = ROOT / "scripts" / "run_codex_logfire_hook.cmd"
+
+
+class HooksConfigTests(unittest.TestCase):
+    def command_hooks(self) -> Iterator[tuple[str, dict[str, Any]]]:
+        config = json.loads(HOOKS_PATH.read_text(encoding="utf-8"))
+        for event_name, groups in config["hooks"].items():
+            for group in groups:
+                for hook in group["hooks"]:
+                    if hook["type"] == "command":
+                        yield event_name, hook
+
+    def test_all_commands_have_platform_launchers_and_expected_timeouts(self) -> None:
+        expected_timeouts = {
+            "SessionStart": 10,
+            "UserPromptSubmit": 10,
+            "PostToolUse": 10,
+            "Stop": 30,
+        }
+        hooks = list(self.command_hooks())
+
+        self.assertEqual({event_name for event_name, _ in hooks}, set(expected_timeouts))
+        for event_name, hook in hooks:
+            self.assertIn("${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}", hook["command"])
+            windows_command = hook["commandWindows"]
+            self.assertIn("%PLUGIN_ROOT%", windows_command)
+            self.assertIn("run_codex_logfire_hook.cmd", windows_command)
+            self.assertNotIn(" sh ", f" {windows_command.lower()} ")
+            self.assertEqual(hook["timeout"], expected_timeouts[event_name])
+
+    def test_windows_launcher_runs_real_hook_and_fails_open(self) -> None:
+        launcher = WINDOWS_LAUNCHER_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("codex_logfire_hook.py", launcher)
+        self.assertIn("CODEX_LOGFIRE_PYTHON", launcher)
+        self.assertIn("exit /b 0", launcher.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/logfire-exporter/tests/test_hooks_config.py
+++ b/plugins/logfire-exporter/tests/test_hooks_config.py
@@ -46,6 +46,18 @@ class HooksConfigTests(unittest.TestCase):
         self.assertIn("CODEX_LOGFIRE_PYTHON", launcher)
         self.assertIn("exit /b 0", launcher.lower())
 
+    def test_windows_launcher_falls_back_after_failed_candidates(self) -> None:
+        launcher = WINDOWS_LAUNCHER_PATH.read_text(encoding="utf-8")
+
+        self.assertIn(
+            'python3 "%~dp0codex_logfire_hook.py"\n    if not errorlevel 1 exit /b 0',
+            launcher,
+        )
+        self.assertIn(
+            'py -3 "%~dp0codex_logfire_hook.py"\n    if not errorlevel 1 exit /b 0',
+            launcher,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
+++ b/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
@@ -105,6 +105,20 @@ class WrapperTests(unittest.TestCase):
         if cached is not None:
             self.assertNotEqual(cached, str(shim))
 
+    def test_watchdog_kills_probe_children(self) -> None:
+        # A hanging shim usually blocks on a child it spawned; the watchdog
+        # must sweep that child too, not orphan it to run to completion.
+        pidfile = self.tmp_path / "child.pid"
+        self.write_executable(
+            self.bin_dir / "python3",
+            f'#!/bin/sh\nsleep 60 &\necho $! > "{pidfile}"\nwait\n',
+        )
+        result = self.run_wrapper(self.base_env())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        child_pid = int(pidfile.read_text(encoding="utf-8").strip())
+        with self.assertRaises(ProcessLookupError):
+            os.kill(child_pid, 0)
+
     def test_env_override_is_trusted_without_probe(self) -> None:
         marker = self.tmp_path / "ran"
         pinned = self.write_fake_interpreter("pinned-python", marker)

--- a/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
+++ b/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
@@ -118,6 +118,18 @@ class WrapperTests(unittest.TestCase):
         if cached is not None:
             self.assertNotEqual(cached, str(shim))
 
+    def test_missing_home_and_state_directory_fails_open(self) -> None:
+        marker = self.tmp_path / "ran"
+        self.write_fake_interpreter("python3", marker)
+        env = self.base_env()
+        env.pop("HOME")
+        env.pop("CODEX_LOGFIRE_STATE_DIR")
+
+        result = self.run_wrapper(env)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(marker.exists())
+
     def test_normalizes_working_directory_before_running_python(self) -> None:
         marker = self.tmp_path / "working-directories"
         self.write_executable(

--- a/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
+++ b/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
@@ -124,6 +124,18 @@ class WrapperTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("codex_logfire_hook.py", marker.read_text(encoding="utf-8"))
 
+    def test_config_file_override_tolerates_whitespace(self) -> None:
+        # The hook's own config parser allows whitespace around '=' and the
+        # value; the wrapper's one-key parser must accept the same shapes.
+        marker = self.tmp_path / "ran"
+        pinned = self.write_fake_interpreter("pinned-python", marker)
+        (self.tmp_path / "config.env").write_text(
+            f"  CODEX_LOGFIRE_PYTHON = '{pinned}'  \n", encoding="utf-8"
+        )
+        result = self.run_wrapper(self.base_env())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("codex_logfire_hook.py", marker.read_text(encoding="utf-8"))
+
     def test_stale_cache_rescans_instead_of_hanging(self) -> None:
         hanging = self.write_hanging_shim("stale-python")
         self.state_dir.mkdir(parents=True)

--- a/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
+++ b/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
@@ -74,6 +74,16 @@ class WrapperTests(unittest.TestCase):
             return None
         return cache.read_text(encoding="utf-8").strip()
 
+    def assert_process_exited(self, pid: int) -> None:
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return
+            time.sleep(0.05)
+        self.fail(f"process {pid} is still present")
+
     def test_healthy_interpreter_runs_hook_and_caches_choice(self) -> None:
         marker = self.tmp_path / "ran"
         self.write_fake_interpreter("python3", marker)
@@ -138,19 +148,23 @@ exit 0
             self.assertEqual(logical_cwd, expected_cwd)
             self.assertEqual(physical_cwd, expected_cwd)
 
-    def test_watchdog_kills_probe_children(self) -> None:
-        # A hanging shim usually blocks on a child it spawned; the watchdog
-        # must sweep that child too, not orphan it to run to completion.
-        pidfile = self.tmp_path / "child.pid"
+    def test_watchdog_kills_complete_probe_process_tree(self) -> None:
+        child_pidfile = self.tmp_path / "child.pid"
+        grandchild_pidfile = self.tmp_path / "grandchild.pid"
         self.write_executable(
             self.bin_dir / "python3",
-            f'#!/bin/sh\nsleep 60 &\necho $! > "{pidfile}"\nwait\n',
+            f'''#!/bin/sh
+/bin/sh -c 'sleep 60 & echo $! > "{grandchild_pidfile}"; wait' &
+echo $! > "{child_pidfile}"
+wait
+''',
         )
         result = self.run_wrapper(self.base_env())
         self.assertEqual(result.returncode, 0, result.stderr)
-        child_pid = int(pidfile.read_text(encoding="utf-8").strip())
-        with self.assertRaises(ProcessLookupError):
-            os.kill(child_pid, 0)
+        child_pid = int(child_pidfile.read_text(encoding="utf-8").strip())
+        grandchild_pid = int(grandchild_pidfile.read_text(encoding="utf-8").strip())
+        self.assert_process_exited(child_pid)
+        self.assert_process_exited(grandchild_pid)
 
     def test_env_override_is_trusted_without_probe(self) -> None:
         marker = self.tmp_path / "ran"

--- a/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
+++ b/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
@@ -130,6 +130,18 @@ class WrapperTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertFalse(marker.exists())
 
+    def test_missing_home_with_state_override_still_probes_python(self) -> None:
+        marker = self.tmp_path / "ran"
+        self.write_fake_interpreter("python3", marker)
+        env = self.base_env()
+        env.pop("HOME")
+        env.pop("CODEX_LOGFIRE_CONFIG_FILE")
+
+        result = self.run_wrapper(env)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("codex_logfire_hook.py", marker.read_text(encoding="utf-8"))
+
     def test_normalizes_working_directory_before_running_python(self) -> None:
         marker = self.tmp_path / "working-directories"
         self.write_executable(

--- a/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
+++ b/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
@@ -246,6 +246,22 @@ wait
         self.assertLess(elapsed, 8.0)
         self.assertEqual(self.cached_interpreter(), str(self.bin_dir / "python3"))
 
+    def test_failed_cached_path_candidate_is_only_probed_once(self) -> None:
+        marker = self.tmp_path / "probe-count"
+        hanging = self.write_executable(
+            self.bin_dir / "python3",
+            f'#!/bin/sh\nprintf "probe\\n" >> "{marker}"\nsleep 60\n',
+        )
+        self.state_dir.mkdir(parents=True)
+        (self.state_dir / "python_interpreter").write_text(
+            f"{hanging}\n", encoding="utf-8"
+        )
+
+        result = self.run_wrapper(self.base_env())
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(marker.read_text(encoding="utf-8").splitlines(), ["probe"])
+
     def test_stdin_reaches_the_hook(self) -> None:
         # The probes must not consume the hook payload: the fake interpreter
         # answers probes (-c) directly and otherwise records stdin.

--- a/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
+++ b/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER_PATH = ROOT / "scripts" / "run_codex_logfire_hook.sh"
+
+# The wrapper itself needs coreutils (dirname, grep, cat, sleep, ...), so the
+# sandboxed PATHs used below always keep the system directories; fake
+# interpreters shadow real ones by coming first.
+SYSTEM_PATH = os.defpath.lstrip(os.pathsep)
+
+
+@unittest.skipIf(sys.platform == "win32", "the hook wrapper targets POSIX shells")
+class WrapperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.tmp_path = Path(self.tmp.name)
+        self.state_dir = self.tmp_path / "state"
+        self.bin_dir = self.tmp_path / "bin"
+        self.bin_dir.mkdir()
+
+    def base_env(self) -> dict[str, str]:
+        # State and config overrides keep the wrapper (and the hook it may
+        # launch) away from the developer's real files.
+        return {
+            "HOME": str(self.tmp_path),
+            "PATH": os.pathsep.join([str(self.bin_dir), SYSTEM_PATH]),
+            "CODEX_LOGFIRE_STATE_DIR": str(self.state_dir),
+            "CODEX_LOGFIRE_CONFIG_FILE": str(self.tmp_path / "config.env"),
+        }
+
+    def write_executable(self, path: Path, body: str) -> Path:
+        path.write_text(body, encoding="utf-8")
+        path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        return path
+
+    def write_fake_interpreter(self, name: str, marker: Path) -> Path:
+        # Answers any invocation (including the probe) and records its argv,
+        # standing in for a working python3 without exec-ing the real hook.
+        return self.write_executable(
+            self.bin_dir / name,
+            f'#!/bin/sh\nprintf \'%s\\n\' "$@" > "{marker}"\nexit 0\n',
+        )
+
+    def write_hanging_shim(self, name: str) -> Path:
+        return self.write_executable(self.bin_dir / name, "#!/bin/sh\nsleep 60\nexit 0\n")
+
+    def run_wrapper(self, env: dict[str, str], stdin: str = "") -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["sh", str(WRAPPER_PATH)],
+            input=stdin,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30.0,
+        )
+
+    def cached_interpreter(self) -> str | None:
+        cache = self.state_dir / "python_interpreter"
+        if not cache.is_file():
+            return None
+        return cache.read_text(encoding="utf-8").strip()
+
+    def test_healthy_interpreter_runs_hook_and_caches_choice(self) -> None:
+        marker = self.tmp_path / "ran"
+        self.write_fake_interpreter("python3", marker)
+        result = self.run_wrapper(self.base_env())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("codex_logfire_hook.py", marker.read_text(encoding="utf-8"))
+        self.assertEqual(self.cached_interpreter(), str(self.bin_dir / "python3"))
+
+    def test_real_interpreter_end_to_end(self) -> None:
+        # With the real Python first on PATH the wrapper must run the real
+        # hook, which exits 0 immediately on empty stdin.
+        env = self.base_env()
+        env["PATH"] = os.pathsep.join([str(Path(sys.executable).parent), SYSTEM_PATH])
+        result = self.run_wrapper(env)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        cached = self.cached_interpreter()
+        if cached is None:
+            self.fail("no interpreter was cached")
+        self.assertTrue(Path(cached).exists())
+
+    def test_hanging_shim_never_stalls_the_hook(self) -> None:
+        # A pyenv-style shim that hangs shadows python3. The wrapper must kill
+        # the probe after ~2s and move on (to a system interpreter when one
+        # exists, else fail open); it must never wait on the shim.
+        shim = self.write_hanging_shim("python3")
+        started = time.monotonic()
+        result = self.run_wrapper(self.base_env())
+        elapsed = time.monotonic() - started
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertLess(elapsed, 8.0)
+        cached = self.cached_interpreter()
+        if cached is not None:
+            self.assertNotEqual(cached, str(shim))
+
+    def test_env_override_is_trusted_without_probe(self) -> None:
+        marker = self.tmp_path / "ran"
+        pinned = self.write_fake_interpreter("pinned-python", marker)
+        env = self.base_env()
+        env["CODEX_LOGFIRE_PYTHON"] = str(pinned)
+        result = self.run_wrapper(env)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("codex_logfire_hook.py", marker.read_text(encoding="utf-8"))
+
+    def test_config_file_override_is_used(self) -> None:
+        marker = self.tmp_path / "ran"
+        pinned = self.write_fake_interpreter("pinned-python", marker)
+        (self.tmp_path / "config.env").write_text(
+            f'CODEX_LOGFIRE_PYTHON="{pinned}"\n', encoding="utf-8"
+        )
+        result = self.run_wrapper(self.base_env())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("codex_logfire_hook.py", marker.read_text(encoding="utf-8"))
+
+    def test_stale_cache_rescans_instead_of_hanging(self) -> None:
+        hanging = self.write_hanging_shim("stale-python")
+        self.state_dir.mkdir(parents=True)
+        (self.state_dir / "python_interpreter").write_text(f"{hanging}\n", encoding="utf-8")
+        marker = self.tmp_path / "ran"
+        self.write_fake_interpreter("python3", marker)
+        started = time.monotonic()
+        result = self.run_wrapper(self.base_env())
+        elapsed = time.monotonic() - started
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(marker.exists(), "rescan did not reach the healthy interpreter")
+        self.assertLess(elapsed, 8.0)
+        self.assertEqual(self.cached_interpreter(), str(self.bin_dir / "python3"))
+
+    def test_stdin_reaches_the_hook(self) -> None:
+        # The probes must not consume the hook payload: the fake interpreter
+        # answers probes (-c) directly and otherwise records stdin.
+        capture = self.tmp_path / "stdin"
+        self.write_executable(
+            self.bin_dir / "python3",
+            f'#!/bin/sh\nif [ "$1" = "-c" ]; then exit 0; fi\ncat > "{capture}"\nexit 0\n',
+        )
+        result = self.run_wrapper(self.base_env(), stdin='{"hook_event_name": "Stop"}')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(capture.read_text(encoding="utf-8"), '{"hook_event_name": "Stop"}')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
+++ b/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
@@ -55,13 +55,16 @@ class WrapperTests(unittest.TestCase):
     def write_hanging_shim(self, name: str) -> Path:
         return self.write_executable(self.bin_dir / name, "#!/bin/sh\nsleep 60\nexit 0\n")
 
-    def run_wrapper(self, env: dict[str, str], stdin: str = "") -> subprocess.CompletedProcess[str]:
+    def run_wrapper(
+        self, env: dict[str, str], stdin: str = "", cwd: Path | None = None
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             ["sh", str(WRAPPER_PATH)],
             input=stdin,
             capture_output=True,
             text=True,
             env=env,
+            cwd=cwd,
             timeout=30.0,
         )
 
@@ -104,6 +107,36 @@ class WrapperTests(unittest.TestCase):
         cached = self.cached_interpreter()
         if cached is not None:
             self.assertNotEqual(cached, str(shim))
+
+    def test_normalizes_working_directory_before_running_python(self) -> None:
+        marker = self.tmp_path / "working-directories"
+        self.write_executable(
+            self.bin_dir / "python3",
+            f'''#!/bin/sh
+printf '%s\t%s\t%s\n' "$1" "$PWD" "$(pwd -P)" >> "{marker}"
+exit 0
+''',
+        )
+        invocation_dir = self.tmp_path / "invocation"
+        invocation_dir.mkdir()
+        env = self.base_env()
+        env["PWD"] = "."
+
+        result = self.run_wrapper(
+            env,
+            stdin='{"hook_event_name": "Stop"}',
+            cwd=invocation_dir,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        records = [line.split("\t") for line in marker.read_text().splitlines()]
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0][0], "-c")
+        self.assertIn("codex_logfire_hook.py", records[1][0])
+        expected_cwd = str(WRAPPER_PATH.parent.resolve())
+        for _, logical_cwd, physical_cwd in records:
+            self.assertEqual(logical_cwd, expected_cwd)
+            self.assertEqual(physical_cwd, expected_cwd)
 
     def test_watchdog_kills_probe_children(self) -> None:
         # A hanging shim usually blocks on a child it spawned; the watchdog

--- a/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
+++ b/plugins/logfire-exporter/tests/test_run_codex_logfire_hook.py
@@ -197,6 +197,29 @@ wait
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("codex_logfire_hook.py", marker.read_text(encoding="utf-8"))
 
+    def test_config_file_falls_back_to_legacy_paths(self) -> None:
+        legacy_directories = ("codex-logfire-exporter", "codex-logfire-plugin")
+        for index, legacy_directory in enumerate(legacy_directories):
+            with self.subTest(legacy_directory=legacy_directory):
+                marker = self.tmp_path / f"legacy-ran-{index}"
+                pinned = self.write_fake_interpreter(f"legacy-python-{index}", marker)
+                config_home = self.tmp_path / f"config-{index}"
+                legacy_config = config_home / legacy_directory / "config.env"
+                legacy_config.parent.mkdir(parents=True)
+                legacy_config.write_text(
+                    f"CODEX_LOGFIRE_PYTHON={pinned}\n", encoding="utf-8"
+                )
+                env = self.base_env()
+                env.pop("CODEX_LOGFIRE_CONFIG_FILE")
+                env["XDG_CONFIG_HOME"] = str(config_home)
+
+                result = self.run_wrapper(env)
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn(
+                    "codex_logfire_hook.py", marker.read_text(encoding="utf-8")
+                )
+
     def test_stale_cache_rescans_instead_of_hanging(self) -> None:
         hanging = self.write_hanging_shim("stale-python")
         self.state_dir.mkdir(parents=True)


### PR DESCRIPTION
On a machine where `python3` resolves to a broken version-manager shim (observed with pyenv on macOS), the shim hangs instead of failing, so every exporter hook runs to its 10-30s timeout. Codex reports "hook timed out after 10s/30s" on each turn and the conversation grinds to a crawl.

Fix: the four hooks now run through `scripts/run_codex_logfire_hook.sh`, which:

- honors an explicit `CODEX_LOGFIRE_PYTHON` override (hook env or `config.env`), trusted without probing;
- otherwise probes candidates (`python3` on `PATH`, then `/usr/bin/python3`, `/opt/homebrew/bin/python3`, `/usr/local/bin/python3`, `python`) with a 2-second watchdog and a Python-3.9+ check, so a hanging shim costs ~2s once instead of a full timeout on every hook;
- caches the working interpreter under the exporter state dir and re-probes the cached choice each run (cheap when healthy), so a cache pointing at a since-broken shim rescans instead of hanging;
- fails open (exit 0, no export) when no interpreter works: telemetry export is never worth breaking the conversation;
- redirects probe stdin away so the hook payload is always delivered intact to the real hook.

Also documents interpreter selection and the timeout symptom in the plugin README troubleshooting section.

Tests: `python3 -m unittest discover -s plugins/logfire-exporter/tests` (7 new wrapper tests covering the healthy path, hanging shim, stale cache, both override mechanisms, stdin passthrough, and end-to-end with the real interpreter; all 18 pass).

Note: I left `plugin.json` at 0.1.0 since the version has never been bumped in-repo; happy to bump if that is part of the release flow.