### PR TITLE
Make the Claude Code plugin MCP URL overridable via LOGFIRE_MCP_URL

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "logfire",
       "description": "Add Logfire observability to Python applications with auto-instrumentation for FastAPI, httpx, asyncpg, SQLAlchemy, and more",
-      "version": "0.1.0",
+      "version": "0.1.4",
       "author": {
         "name": "Pydantic",
         "email": "support@pydantic.dev"

--- a/plugins/logfire/.claude-plugin/plugin.json
+++ b/plugins/logfire/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "logfire",
   "description": "Add Logfire observability to Python applications with auto-instrumentation for FastAPI, httpx, asyncpg, SQLAlchemy, and more",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "Pydantic",
     "email": "support@pydantic.dev"

--- a/plugins/logfire/.codex-plugin/mcp.json
+++ b/plugins/logfire/.codex-plugin/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "logfire": {
       "type": "http",
-      "url": "${LOGFIRE_MCP_URL:-https://logfire-us.pydantic.dev/mcp}"
+      "url": "https://logfire-us.pydantic.dev/mcp"
     }
   }
 }

--- a/plugins/logfire/.codex-plugin/plugin.json
+++ b/plugins/logfire/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "logfire",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Add Logfire observability to Python applications with auto-instrumentation for FastAPI, httpx, asyncpg, SQLAlchemy, and more",
   "author": {
     "name": "Pydantic",
@@ -18,7 +18,7 @@
     "pydantic"
   ],
   "skills": "./skills/",
-  "mcpServers": "./.mcp.json",
+  "mcpServers": "./.codex-plugin/mcp.json",
   "interface": {
     "displayName": "Logfire",
     "shortDescription": "Investigate telemetry and add Logfire instrumentation.",

--- a/plugins/logfire/.cursor-plugin/plugin.json
+++ b/plugins/logfire/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "logfire",
   "displayName": "Logfire",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Add Logfire observability to Python applications with auto-instrumentation for FastAPI, httpx, asyncpg, SQLAlchemy, and more. Query traces, investigate errors, and open Logfire UI views from Cursor.",
   "author": {
     "name": "Pydantic",

--- a/plugins/logfire/README.md
+++ b/plugins/logfire/README.md
@@ -48,7 +48,7 @@ Then enable **Logfire** from the Codex plugin UI. The Codex plugin metadata live
 - capabilities **Interactive** and **Write**
 - Logfire icon and pink brand color
 - Logfire skills for instrumentation, querying, and UI-opening workflows
-- MCP server from `.mcp.json`
+- MCP server from `.codex-plugin/mcp.json`
 
 For local development after changing this plugin, refresh the Codex plugin cache:
 
@@ -76,9 +76,23 @@ Then restart Cursor or run **Developer: Reload Window**. The Cursor plugin metad
 
 ## MCP
 
-The Logfire MCP server is configured automatically when you install the plugin (US region).
+The Logfire MCP server is configured automatically when you install the plugin. By default it
+targets the US region endpoint (`https://logfire-us.pydantic.dev/mcp`). The plugin's skills and
+commands are region-independent; only the MCP server entry differs per region.
 
-Codex users can switch to the EU endpoint without editing plugin files by replacing the MCP entry and re-authenticating:
+### EU region and self-hosted instances
+
+**Claude Code** reads the endpoint from the `LOGFIRE_MCP_URL` environment variable, so set it in
+the shell where you launch Claude Code:
+
+```bash
+export LOGFIRE_MCP_URL=https://logfire-eu.pydantic.dev/mcp
+```
+
+(On plugin versions before 0.1.4, the URL is hardcoded; add the endpoint manually instead with
+`claude mcp add --transport http logfire https://logfire-eu.pydantic.dev/mcp`.)
+
+**Codex** users can switch by replacing the MCP entry and re-authenticating:
 
 ```bash
 codex mcp remove logfire
@@ -89,12 +103,10 @@ codex mcp get logfire
 
 Start a new Codex conversation after switching so the MCP tools reload.
 
-Claude Code users can switch by running:
+**Cursor** installs are a local copy, so edit the `url` in
+`~/.cursor/plugins/local/logfire/mcp.json` and reload the window.
 
-```
-claude mcp add logfire --transport http https://logfire-eu.pydantic.dev/mcp
-```
-
-In Codex, `.mcp.json` configures the `logfire` MCP server. In Cursor, `mcp.json` configures the same hosted server.
+In Claude Code, `.mcp.json` configures the `logfire` MCP server. In Codex, `.codex-plugin/mcp.json`
+configures it. In Cursor, `mcp.json` configures the same hosted server.
 
 The Logfire MCP server requires normal Logfire authentication, such as `logfire auth` or a suitable `LOGFIRE_TOKEN`.

--- a/plugins/logfire/README.md
+++ b/plugins/logfire/README.md
@@ -89,13 +89,18 @@ the shell where you launch Claude Code:
 export LOGFIRE_MCP_URL=https://logfire-eu.pydantic.dev/mcp
 ```
 
-This needs plugin version 0.1.4 or later (`claude plugin list` shows the installed version); on
-earlier versions the URL is hardcoded. Update an older install and restart Claude Code:
+This needs plugin version 0.1.4 or later; on earlier versions the URL is hardcoded. Run
+`claude plugin list` to see the installed version and the marketplace it came from, then update
+and restart Claude Code:
 
 ```bash
-claude plugin marketplace update claude-plugins-official
-claude plugin update logfire@claude-plugins-official
+claude plugin marketplace update pydantic-skills
+claude plugin update logfire@pydantic-skills
 ```
+
+If you installed from Anthropic's `claude-plugins-official` marketplace instead, substitute that
+name. That marketplace pins a specific commit of this repository, so a release can take longer to
+appear there than on `pydantic-skills`, which tracks `main`.
 
 **Codex** users can switch by replacing the MCP entry and re-authenticating:
 

--- a/plugins/logfire/README.md
+++ b/plugins/logfire/README.md
@@ -89,8 +89,13 @@ the shell where you launch Claude Code:
 export LOGFIRE_MCP_URL=https://logfire-eu.pydantic.dev/mcp
 ```
 
-(On plugin versions before 0.1.4, the URL is hardcoded; add the endpoint manually instead with
-`claude mcp add --transport http logfire https://logfire-eu.pydantic.dev/mcp`.)
+This needs plugin version 0.1.4 or later (`claude plugin list` shows the installed version); on
+earlier versions the URL is hardcoded. Update an older install and restart Claude Code:
+
+```bash
+claude plugin marketplace update claude-plugins-official
+claude plugin update logfire@claude-plugins-official
+```
 
 **Codex** users can switch by replacing the MCP entry and re-authenticating:
 


### PR DESCRIPTION
The Logfire plugin hardcodes the US MCP endpoint, so EU and self-hosted users who install it get an MCP server pointed at the wrong region and have to tear the entry out by hand.

## Changes

- `.mcp.json` (Claude Code): the server URL is now `${LOGFIRE_MCP_URL:-https://logfire-us.pydantic.dev/mcp}`. Claude Code expands `${VAR:-default}` in `.mcp.json` `url` fields ([docs](https://code.claude.com/docs/en/mcp#environment-variable-expansion-in-mcp-json)), so US users see no change and EU/self-hosted users just `export LOGFIRE_MCP_URL=...` before launching Claude Code.
- Codex previously shared `.mcp.json`; Codex does not expand that syntax, so `.codex-plugin/plugin.json` now points at a new static `.codex-plugin/mcp.json` (unchanged US URL). The documented `codex mcp remove/add/login` swap remains the EU path for Codex.
- README: region section rewritten around the env var, with the pre-0.1.4 fallback and the Cursor local-copy note.
- Version bumped to 0.1.4 in the three plugin manifests.

An alternative considered was plugin `userConfig` (Claude Code prompts for the URL when enabling the plugin); the env var was chosen because it also works headless/CI and on older Claude Code versions the unexpanded `${user_config.*}` reference would break the default install, whereas `${VAR:-default}` expansion has been supported much longer. Happy to switch if maintainers prefer the prompt UX.

Related: pydantic/logfire#2208 (docs MCP guide rework, which will reference `LOGFIRE_MCP_URL` for EU once this lands).
