### PR TITLE
Publish Agent Skills after main updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
       - name: Verify plugin and standalone skill copies are in sync
         run: bash scripts/check-skill-sync.sh
+
+  publish-agent-skills:
+    name: Publish Agent Skills
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: check-skill-sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: unified-docs
+          permission-contents: write
+
+      - name: Trigger unified-docs publication
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          gh api repos/pydantic/unified-docs/dispatches \
+            --method POST \
+            -f event_type=docs-update \
+            -f "client_payload[source]=pydantic/skills@${SOURCE_SHA}"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ The Logfire MCP server requires normal Logfire authentication, such as `logfire 
 
 The `skills/` directory contains standalone SKILL.md files compatible with 30+ agents via the [agentskills.io](https://agentskills.io) standard - including Codex, Cursor, Gemini CLI, and Claude Code.
 
+Released skills are also published through the [Agent Skills Discovery](https://github.com/cloudflare/agent-skills-discovery-rfc) API at
+[`pydantic.dev/.well-known/agent-skills`](https://pydantic.dev/.well-known/agent-skills). After a change reaches `main` and passes this repository's sync check, CI asks
+`pydantic/unified-docs` to build and verify immutable, content-addressed artifacts from that exact commit. The generated discovery index and archives are deployment
+artifacts; do not maintain copies in this repository.
+
 | Skill                                                              | Description                                                                         |
 | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
 | [logfire-instrumentation](skills/logfire-instrumentation/)         | Add Logfire observability to Python, JS/TS, and Rust apps                           |


### PR DESCRIPTION
## Summary

- dispatch an exact pydantic/skills main-branch commit to unified-docs after the skill-sync check succeeds
- authenticate with the same short-lived GitHub App pattern used by pydantic-ai
- document pydantic.dev as the generated Agent Skills Discovery endpoint and keep generated artifacts out of the source repository

Depends on pydantic/unified-docs#234 and tracks pydantic/unified-docs#233.

## Deployment prerequisite

This repository needs access to DOCS_APP_ID and DOCS_APP_PRIVATE_KEY, with the app allowed to dispatch to pydantic/unified-docs. The names match the existing pydantic-ai setup.

## Validation

- bash scripts/check-skill-sync.sh
- actionlint .github/workflows/ci.yml
- uvx zizmor@1.28.0 .github/workflows/ci.yml
- git diff --check